### PR TITLE
Milestone 16A–16C: Opportunities API, Clubs API, helpers filtri/paginazione

### DIFF
--- a/app/(dashboard)/clubs/page.tsx
+++ b/app/(dashboard)/clubs/page.tsx
@@ -10,15 +10,22 @@ import { useToast } from "@/components/common/ToastProvider";
 import PrevNextPager from "@/components/common/PrevNextPager";
 import ResultBadge from "@/components/common/ResultBadge";
 
+// ✅ helpers unificati (16C)
+import {
+  buildQuery,
+  parseFilters,
+  parsePage,
+} from "@/lib/search/params";
+
 const PAGE_SIZE = 20;
 
 type Club = {
   id: string;
   name: string;
-  country?: string;
+  country?: "IT" | "ES" | "FR" | "DE" | "UK" | "US" | string;
   city?: string;
-  role?: string;
-  status?: string;
+  role?: string; // compat con colonna esistente (non filtrata dall'API)
+  status?: "active" | "inactive" | "archived" | string;
   [key: string]: unknown;
 };
 
@@ -26,38 +33,20 @@ export default function ClubsPage() {
   const sp = useSearchParams();
   const { error: toastError } = useToast();
 
-  const q = sp.get("q") ?? "";
-  const role = sp.get("role") ?? "";
-  const country = sp.get("country") ?? "";
-  const status = sp.get("status") ?? "";
-  const city = sp.get("city") ?? "";
-  const from = sp.get("from") ?? "";
-  const to = sp.get("to") ?? "";
-
-  const page = useMemo(() => {
-    const raw = sp.get("page");
-    const n = raw ? parseInt(raw, 10) : 1;
-    return Number.isFinite(n) && n > 0 ? n : 1;
-  }, [sp]);
+  // ✅ page + filtri centralizzati
+  const page = useMemo(() => parsePage(sp), [sp]);
+  const filters = useMemo(() => parseFilters(sp), [sp]);
 
   const [items, setItems] = useState<Club[]>([]);
   const [total, setTotal] = useState<number | null>(null);
   const [hasMore, setHasMore] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
 
-  const query = useMemo(() => {
-    const p = new URLSearchParams();
-    p.set("page", String(page));
-    p.set("limit", String(PAGE_SIZE));
-    if (q) p.set("q", q);
-    if (role) p.set("role", role);
-    if (country) p.set("country", country);
-    if (status) p.set("status", status);
-    if (city) p.set("city", city);
-    if (from) p.set("from", from);
-    if (to) p.set("to", to);
-    return p.toString();
-  }, [page, q, role, country, status, city, from, to]);
+  // ✅ query string coerente in tutta l'app
+  const query = useMemo(
+    () => buildQuery(filters, page, PAGE_SIZE),
+    [filters, page]
+  );
 
   useEffect(() => {
     const ac = new AbortController();
@@ -80,9 +69,7 @@ export default function ClubsPage() {
         setItems(list);
         setTotal(typeof data.total === "number" ? data.total : null);
         setHasMore(
-          typeof data.hasMore === "boolean"
-            ? data.hasMore
-            : list.length === PAGE_SIZE
+          typeof data.hasMore === "boolean" ? data.hasMore : list.length === PAGE_SIZE
         );
       } catch (err) {
         toastError("", {
@@ -137,7 +124,7 @@ export default function ClubsPage() {
                     <td className="px-3 py-2">{c.city ?? "—"}</td>
                     <td className="px-3 py-2">{c.country ?? "—"}</td>
                     <td className="px-3 py-2">{c.role ?? "—"}</td>
-                    <td className="px-3 py-2">{(c as any).status ?? "—"}</td>
+                    <td className="px-3 py-2">{c.status ?? "—"}</td>
                   </tr>
                 ))}
               </tbody>
@@ -150,7 +137,13 @@ export default function ClubsPage() {
         )}
 
         <div className="mt-4 flex items-center justify-between gap-3">
-          <ResultBadge total={total} page={page} pageSize={PAGE_SIZE} hasMore={hasMore} label="Clubs" />
+          <ResultBadge
+            total={total}
+            page={page}
+            pageSize={PAGE_SIZE}
+            hasMore={hasMore}
+            label="Clubs"
+          />
           <PrevNextPager currentPage={page} hasMore={hasMore} label="Clubs" />
         </div>
       </div>

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -4,37 +4,64 @@ import { NextRequest, NextResponse } from "next/server";
 type Club = {
   id: string;
   name: string;
+  country?: "IT" | "ES" | "FR" | "DE" | "UK" | "US";
   city?: string;
-  country?: string;
-  role?: string;
-  status?: string;
+  status?: "active" | "inactive" | "archived";
+  createdAt: string; // YYYY-MM-DD
 };
 
-const MOCK: Club[] = Array.from({ length: 87 }).map((_, i) => ({
-  id: String(i + 1),
-  name: `Club ${i + 1}`,
-  city: i % 3 === 0 ? "Roma" : i % 3 === 1 ? "Milano" : "Torino",
-  country: i % 2 === 0 ? "IT" : "ES",
-  role: i % 4 === 0 ? "coach" : i % 4 === 1 ? "player" : i % 4 === 2 ? "staff" : "scout",
-  status: i % 5 === 0 ? "open" : i % 5 === 1 ? "closed" : i % 5 === 2 ? "draft" : "archived",
-}));
+const startDate = new Date();
+startDate.setMonth(startDate.getMonth() - 9);
 
+function addDays(d: Date, days: number) {
+  const x = new Date(d);
+  x.setDate(x.getDate() + days);
+  return x;
+}
+
+const COUNTRIES: NonNullable<Club["country"]>[] = ["IT", "ES", "FR", "DE", "UK", "US"];
+const CITIES = ["Roma", "Milano", "Torino", "Madrid", "Paris", "Berlin", "London", "New York"];
+const STATUSES: NonNullable<Club["status"]>[] = ["active", "inactive", "archived"];
+const CLUB_NAMES = [
+  "Atlético Carlentini","Sporting Madrid","Paris Étoile","Berlin Adler",
+  "London Lions","New York Cosmos","Torino Granata","Milano Navigli",
+];
+
+const MOCK: Club[] = Array.from({ length: 87 }).map((_, i) => {
+  const country = COUNTRIES[i % COUNTRIES.length];
+  const city = CITIES[i % CITIES.length];
+  const status = STATUSES[i % STATUSES.length];
+  const createdAt = addDays(startDate, i).toISOString().slice(0, 10);
+  const baseName = CLUB_NAMES[i % CLUB_NAMES.length];
+  return { id: String(i + 1), name: `${baseName} ${i + 1}`, country, city, status, createdAt };
+});
+
+function parseIntSafe(v: string | null, def: number) {
+  if (!v) return def;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+function inDateRange(dateISO: string, from?: string | null, to?: string | null) {
+  if (!from && !to) return true;
+  const d = dateISO;
+  if (from && d < from) return false;
+  if (to && d > to) return false;
+  return true;
+}
 function applyFilters(items: Club[], sp: URLSearchParams) {
-  const q = sp.get("q")?.toLowerCase() ?? "";
-  const role = sp.get("role") ?? "";
+  const q = (sp.get("q") ?? "").toLowerCase();
   const country = sp.get("country") ?? "";
   const status = sp.get("status") ?? "";
-  const city = sp.get("city")?.toLowerCase() ?? "";
+  const city = (sp.get("city") ?? "").toLowerCase();
+  const from = sp.get("from");
+  const to = sp.get("to");
 
-  let out = items.slice();
-
-  if (q) out = out.filter((c) => c.name.toLowerCase().includes(q));
-  if (role) out = out.filter((c) => (c.role ?? "") === role);
-  if (country) out = out.filter((c) => (c.country ?? "") === country);
-  if (status) out = out.filter((c) => (c.status ?? "") === status);
-  if (city) out = out.filter((c) => (c.city ?? "").toLowerCase().includes(city));
-
-  // from/to ignorati nello stub (pronti per estensione con date reali)
+  let out = items;
+  if (q) out = out.filter(c => c.name.toLowerCase().includes(q) || (c.city ?? "").toLowerCase().includes(q));
+  if (country) out = out.filter(c => (c.country ?? "") === country);
+  if (status) out = out.filter(c => (c.status ?? "") === status);
+  if (city) out = out.filter(c => (c.city ?? "").toLowerCase().includes(city));
+  if (from || to) out = out.filter(c => inDateRange(c.createdAt, from, to));
   return out;
 }
 
@@ -42,15 +69,14 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const sp = url.searchParams;
 
-  const page = Math.max(1, parseInt(sp.get("page") || "1", 10) || 1);
-  const limit = Math.min(100, Math.max(1, parseInt(sp.get("limit") || "20", 10) || 20));
+  const page = parseIntSafe(sp.get("page"), 1);
+  const limit = Math.min(100, parseIntSafe(sp.get("limit"), 20));
 
   const filtered = applyFilters(MOCK, sp);
   const total = filtered.length;
 
   const start = (page - 1) * limit;
   const end = start + limit;
-
   const items = filtered.slice(start, end);
   const hasMore = end < total;
 

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -1,84 +1,19 @@
-// app/api/clubs/route.ts
 import { NextRequest, NextResponse } from "next/server";
-
-type Club = {
-  id: string;
-  name: string;
-  country?: "IT" | "ES" | "FR" | "DE" | "UK" | "US";
-  city?: string;
-  status?: "active" | "inactive" | "archived";
-  createdAt: string; // YYYY-MM-DD
-};
-
-const startDate = new Date();
-startDate.setMonth(startDate.getMonth() - 9);
-
-function addDays(d: Date, days: number) {
-  const x = new Date(d);
-  x.setDate(x.getDate() + days);
-  return x;
-}
-
-const COUNTRIES: NonNullable<Club["country"]>[] = ["IT", "ES", "FR", "DE", "UK", "US"];
-const CITIES = ["Roma", "Milano", "Torino", "Madrid", "Paris", "Berlin", "London", "New York"];
-const STATUSES: NonNullable<Club["status"]>[] = ["active", "inactive", "archived"];
-const CLUB_NAMES = [
-  "Atlético Carlentini","Sporting Madrid","Paris Étoile","Berlin Adler",
-  "London Lions","New York Cosmos","Torino Granata","Milano Navigli",
-];
-
-const MOCK: Club[] = Array.from({ length: 87 }).map((_, i) => {
-  const country = COUNTRIES[i % COUNTRIES.length];
-  const city = CITIES[i % CITIES.length];
-  const status = STATUSES[i % STATUSES.length];
-  const createdAt = addDays(startDate, i).toISOString().slice(0, 10);
-  const baseName = CLUB_NAMES[i % CLUB_NAMES.length];
-  return { id: String(i + 1), name: `${baseName} ${i + 1}`, country, city, status, createdAt };
-});
-
-function parseIntSafe(v: string | null, def: number) {
-  if (!v) return def;
-  const n = parseInt(v, 10);
-  return Number.isFinite(n) && n > 0 ? n : def;
-}
-function inDateRange(dateISO: string, from?: string | null, to?: string | null) {
-  if (!from && !to) return true;
-  const d = dateISO;
-  if (from && d < from) return false;
-  if (to && d > to) return false;
-  return true;
-}
-function applyFilters(items: Club[], sp: URLSearchParams) {
-  const q = (sp.get("q") ?? "").toLowerCase();
-  const country = sp.get("country") ?? "";
-  const status = sp.get("status") ?? "";
-  const city = (sp.get("city") ?? "").toLowerCase();
-  const from = sp.get("from");
-  const to = sp.get("to");
-
-  let out = items;
-  if (q) out = out.filter(c => c.name.toLowerCase().includes(q) || (c.city ?? "").toLowerCase().includes(q));
-  if (country) out = out.filter(c => (c.country ?? "") === country);
-  if (status) out = out.filter(c => (c.status ?? "") === status);
-  if (city) out = out.filter(c => (c.city ?? "").toLowerCase().includes(city));
-  if (from || to) out = out.filter(c => inDateRange(c.createdAt, from, to));
-  return out;
-}
+import { ClubsRepo } from "@/lib/data/clubs";
+import { parseFilters, parseLimit, parsePage } from "@/lib/search/params";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const sp = url.searchParams;
 
-  const page = parseIntSafe(sp.get("page"), 1);
-  const limit = Math.min(100, parseIntSafe(sp.get("limit"), 20));
+  const page = parsePage(sp);
+  const limit = Math.min(100, parseLimit(sp));
+  const f = parseFilters(sp);
 
-  const filtered = applyFilters(MOCK, sp);
-  const total = filtered.length;
+  const useDB = process.env.DATA_SOURCE === "db";
+  const data = useDB
+    ? await ClubsRepo.searchDB(f, { page, limit })
+    : await ClubsRepo.search(f, { page, limit });
 
-  const start = (page - 1) * limit;
-  const end = start + limit;
-  const items = filtered.slice(start, end);
-  const hasMore = end < total;
-
-  return NextResponse.json({ items, total, hasMore });
+  return NextResponse.json(data);
 }

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -1,19 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ClubsRepo } from "@/lib/data/clubs";
 import { parseFilters, parseLimit, parsePage } from "@/lib/search/params";
+import { withApiHandler } from "@/lib/api/handler";
+import { badRequest } from "@/lib/api/errors";
 
-export async function GET(req: NextRequest) {
+export const GET = withApiHandler(async (req: NextRequest) => {
   const url = new URL(req.url);
   const sp = url.searchParams;
 
   const page = parsePage(sp);
   const limit = Math.min(100, parseLimit(sp));
-  const f = parseFilters(sp);
+  if (limit <= 0) throw badRequest("limit must be > 0");
 
+  const f = parseFilters(sp);
   const useDB = process.env.DATA_SOURCE === "db";
   const data = useDB
     ? await ClubsRepo.searchDB(f, { page, limit })
     : await ClubsRepo.search(f, { page, limit });
 
   return NextResponse.json(data);
-}
+});

--- a/app/api/opportunities/route.ts
+++ b/app/api/opportunities/route.ts
@@ -4,37 +4,102 @@ import { NextRequest, NextResponse } from "next/server";
 type Opportunity = {
   id: string;
   title: string;
-  club?: string;
-  location?: string;
-  postedAt?: string; // ISO
+  role?: "player" | "coach" | "staff" | "scout" | "director";
+  country?: "IT" | "ES" | "FR" | "DE" | "UK" | "US";
+  city?: string;
+  status?: "open" | "closed" | "draft" | "archived";
+  createdAt: string; // ISO date
 };
 
-const TOTAL = 125; // numero fittizio per simulare più pagine
+// ---- Mock dataset (in-memory) ----
+const startDate = new Date();
+startDate.setMonth(startDate.getMonth() - 6);
 
-function makeItem(i: number): Opportunity {
-  const day = (i % 28) + 1;
-  return {
-    id: `op_${i}`,
-    title: `Opportunity #${i}`,
-    club: `Club ${i % 7}`,
-    location: ["Roma", "Milano", "Torino", "Bologna"][i % 4],
-    postedAt: `2024-11-${String(day).padStart(2, "0")}T12:00:00.000Z`,
-  };
+function addDays(d: Date, days: number) {
+  const x = new Date(d);
+  x.setDate(x.getDate() + days);
+  return x;
 }
 
+const ROLES: Opportunity["role"][] = ["player", "coach", "staff", "scout", "director"];
+const COUNTRIES: Opportunity["country"][] = ["IT", "ES", "FR", "DE", "UK", "US"];
+const CITIES = ["Roma", "Milano", "Torino", "Madrid", "Paris", "Berlin", "London", "New York"];
+const STATUSES: NonNullable<Opportunity["status"]>[] = ["open", "closed", "draft", "archived"];
+
+const MOCK: Opportunity[] = Array.from({ length: 123 }).map((_, i) => {
+  const role = ROLES[i % ROLES.length];
+  const country = COUNTRIES[i % COUNTRIES.length];
+  const city = CITIES[i % CITIES.length];
+  const status = STATUSES[i % STATUSES.length];
+  const createdAt = addDays(startDate, i).toISOString().slice(0, 10); // YYYY-MM-DD
+  return {
+    id: String(i + 1),
+    title: `Opportunity ${i + 1} — ${role} @ ${city}`,
+    role,
+    country,
+    city,
+    status,
+    createdAt,
+  };
+});
+
+// ---- Helpers ----
+function parseIntSafe(v: string | null, def: number) {
+  if (!v) return def;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+function inDateRange(dateISO: string, from?: string | null, to?: string | null) {
+  if (!from && !to) return true;
+  const d = dateISO;
+  if (from && d < from) return false;
+  if (to && d > to) return false;
+  return true;
+}
+
+function applyFilters(items: Opportunity[], sp: URLSearchParams) {
+  const q = (sp.get("q") ?? "").toLowerCase();
+  const role = sp.get("role") ?? "";
+  const country = sp.get("country") ?? "";
+  const status = sp.get("status") ?? "";
+  const city = (sp.get("city") ?? "").toLowerCase();
+  const from = sp.get("from"); // YYYY-MM-DD
+  const to = sp.get("to");     // YYYY-MM-DD
+
+  let out = items;
+
+  if (q) {
+    out = out.filter(
+      (o) =>
+        o.title.toLowerCase().includes(q) ||
+        (o.city ?? "").toLowerCase().includes(q)
+    );
+  }
+  if (role) out = out.filter((o) => (o.role ?? "") === role);
+  if (country) out = out.filter((o) => (o.country ?? "") === country);
+  if (status) out = out.filter((o) => (o.status ?? "") === status);
+  if (city) out = out.filter((o) => (o.city ?? "").toLowerCase().includes(city));
+  if (from || to) out = out.filter((o) => inDateRange(o.createdAt, from, to));
+
+  return out;
+}
+
+// ---- Handler ----
 export async function GET(req: NextRequest) {
-  // es: /api/opportunities?page=1&limit=20
-  const { searchParams } = new URL(req.url);
-  const page = Number(searchParams.get("page") ?? "1");
-  const limit = Math.min(Number(searchParams.get("limit") ?? "20"), 100);
+  const url = new URL(req.url);
+  const sp = url.searchParams;
+
+  const page = parseIntSafe(sp.get("page"), 1);
+  const limit = Math.min(100, parseIntSafe(sp.get("limit"), 20));
+
+  const filtered = applyFilters(MOCK, sp);
+  const total = filtered.length;
 
   const start = (page - 1) * limit;
-  const end = Math.min(start + limit, TOTAL);
+  const end = start + limit;
+  const items = filtered.slice(start, end);
+  const hasMore = end < total;
 
-  const items: Opportunity[] = [];
-  for (let i = start; i < end; i++) items.push(makeItem(i + 1));
-
-  const hasMore = end < TOTAL;
-
-  return NextResponse.json({ items, total: TOTAL, hasMore });
+  return NextResponse.json({ items, total, hasMore });
 }

--- a/app/api/opportunities/route.ts
+++ b/app/api/opportunities/route.ts
@@ -1,105 +1,19 @@
-// app/api/opportunities/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { OpportunitiesRepo } from "@/lib/data/opportunities";
+import { parseFilters, parseLimit, parsePage } from "@/lib/search/params";
 
-type Opportunity = {
-  id: string;
-  title: string;
-  role?: "player" | "coach" | "staff" | "scout" | "director";
-  country?: "IT" | "ES" | "FR" | "DE" | "UK" | "US";
-  city?: string;
-  status?: "open" | "closed" | "draft" | "archived";
-  createdAt: string; // ISO date
-};
-
-// ---- Mock dataset (in-memory) ----
-const startDate = new Date();
-startDate.setMonth(startDate.getMonth() - 6);
-
-function addDays(d: Date, days: number) {
-  const x = new Date(d);
-  x.setDate(x.getDate() + days);
-  return x;
-}
-
-const ROLES: Opportunity["role"][] = ["player", "coach", "staff", "scout", "director"];
-const COUNTRIES: Opportunity["country"][] = ["IT", "ES", "FR", "DE", "UK", "US"];
-const CITIES = ["Roma", "Milano", "Torino", "Madrid", "Paris", "Berlin", "London", "New York"];
-const STATUSES: NonNullable<Opportunity["status"]>[] = ["open", "closed", "draft", "archived"];
-
-const MOCK: Opportunity[] = Array.from({ length: 123 }).map((_, i) => {
-  const role = ROLES[i % ROLES.length];
-  const country = COUNTRIES[i % COUNTRIES.length];
-  const city = CITIES[i % CITIES.length];
-  const status = STATUSES[i % STATUSES.length];
-  const createdAt = addDays(startDate, i).toISOString().slice(0, 10); // YYYY-MM-DD
-  return {
-    id: String(i + 1),
-    title: `Opportunity ${i + 1} — ${role} @ ${city}`,
-    role,
-    country,
-    city,
-    status,
-    createdAt,
-  };
-});
-
-// ---- Helpers ----
-function parseIntSafe(v: string | null, def: number) {
-  if (!v) return def;
-  const n = parseInt(v, 10);
-  return Number.isFinite(n) && n > 0 ? n : def;
-}
-
-function inDateRange(dateISO: string, from?: string | null, to?: string | null) {
-  if (!from && !to) return true;
-  const d = dateISO;
-  if (from && d < from) return false;
-  if (to && d > to) return false;
-  return true;
-}
-
-function applyFilters(items: Opportunity[], sp: URLSearchParams) {
-  const q = (sp.get("q") ?? "").toLowerCase();
-  const role = sp.get("role") ?? "";
-  const country = sp.get("country") ?? "";
-  const status = sp.get("status") ?? "";
-  const city = (sp.get("city") ?? "").toLowerCase();
-  const from = sp.get("from"); // YYYY-MM-DD
-  const to = sp.get("to");     // YYYY-MM-DD
-
-  let out = items;
-
-  if (q) {
-    out = out.filter(
-      (o) =>
-        o.title.toLowerCase().includes(q) ||
-        (o.city ?? "").toLowerCase().includes(q)
-    );
-  }
-  if (role) out = out.filter((o) => (o.role ?? "") === role);
-  if (country) out = out.filter((o) => (o.country ?? "") === country);
-  if (status) out = out.filter((o) => (o.status ?? "") === status);
-  if (city) out = out.filter((o) => (o.city ?? "").toLowerCase().includes(city));
-  if (from || to) out = out.filter((o) => inDateRange(o.createdAt, from, to));
-
-  return out;
-}
-
-// ---- Handler ----
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const sp = url.searchParams;
 
-  const page = parseIntSafe(sp.get("page"), 1);
-  const limit = Math.min(100, parseIntSafe(sp.get("limit"), 20));
+  const page = parsePage(sp);
+  const limit = Math.min(100, parseLimit(sp));
+  const f = parseFilters(sp);
 
-  const filtered = applyFilters(MOCK, sp);
-  const total = filtered.length;
+  const useDB = process.env.DATA_SOURCE === "db";
+  const data = useDB
+    ? await OpportunitiesRepo.searchDB(f, { page, limit })
+    : await OpportunitiesRepo.search(f, { page, limit });
 
-  const start = (page - 1) * limit;
-  const end = start + limit;
-  const items = filtered.slice(start, end);
-  const hasMore = end < total;
-
-  return NextResponse.json({ items, total, hasMore });
+  return NextResponse.json(data);
 }

--- a/app/api/opportunities/route.ts
+++ b/app/api/opportunities/route.ts
@@ -1,19 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { OpportunitiesRepo } from "@/lib/data/opportunities";
 import { parseFilters, parseLimit, parsePage } from "@/lib/search/params";
+import { withApiHandler } from "@/lib/api/handler";
+import { badRequest } from "@/lib/api/errors";
 
-export async function GET(req: NextRequest) {
+export const GET = withApiHandler(async (req: NextRequest) => {
   const url = new URL(req.url);
   const sp = url.searchParams;
 
   const page = parsePage(sp);
   const limit = Math.min(100, parseLimit(sp));
-  const f = parseFilters(sp);
+  if (limit <= 0) throw badRequest("limit must be > 0");
 
+  const f = parseFilters(sp);
   const useDB = process.env.DATA_SOURCE === "db";
   const data = useDB
     ? await OpportunitiesRepo.searchDB(f, { page, limit })
     : await OpportunitiesRepo.search(f, { page, limit });
 
   return NextResponse.json(data);
-}
+});

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -1,33 +1,62 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ViewsRepo } from "@/lib/data/views";
 import { withApiHandler } from "@/lib/api/handler";
 import { badRequest } from "@/lib/api/errors";
+import { createClient } from "@supabase/supabase-js";
+
+// Supabase client con Service Role Key (solo lato server)
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
 
 export const GET = withApiHandler(async (req: NextRequest) => {
   const url = new URL(req.url);
   const scope = url.searchParams.get("scope");
   if (!scope) throw badRequest("Missing scope");
-  const data = await ViewsRepo.list(scope as any);
-  return NextResponse.json({ items: data });
+
+  // L’RLS farà in modo che vengano restituite solo le viste dell’utente corrente
+  const { data, error } = await supabase
+    .from("saved_views")
+    .select("*")
+    .eq("scope", scope)
+    .order("created_at", { ascending: false });
+
+  if (error) throw badRequest(error.message);
+
+  return NextResponse.json({ items: data ?? [] });
 });
 
 export const POST = withApiHandler(async (req: NextRequest) => {
   const body = await req.json();
-  if (!body.scope || !body.name || !body.filters) {
+  if (!body.scope || !body.name || !body.filters || !body.user_id) {
     throw badRequest("Missing fields");
   }
-  const view = await ViewsRepo.create({
-    scope: body.scope,
-    name: body.name,
-    filters: body.filters,
-  });
-  return NextResponse.json(view, { status: 201 });
+
+  const { data, error } = await supabase
+    .from("saved_views")
+    .insert([
+      {
+        scope: body.scope,
+        name: body.name,
+        filters: body.filters,
+        user_id: body.user_id,
+      },
+    ])
+    .select()
+    .single();
+
+  if (error) throw badRequest(error.message);
+
+  return NextResponse.json(data, { status: 201 });
 });
 
 export const DELETE = withApiHandler(async (req: NextRequest) => {
   const url = new URL(req.url);
   const id = url.searchParams.get("id");
   if (!id) throw badRequest("Missing id");
-  await ViewsRepo.remove(id);
+
+  const { error } = await supabase.from("saved_views").delete().eq("id", id);
+  if (error) throw badRequest(error.message);
+
   return NextResponse.json({ ok: true });
 });

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -1,87 +1,33 @@
-// app/api/views/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { ViewsRepo } from "@/lib/data/views";
+import { withApiHandler } from "@/lib/api/handler";
+import { badRequest } from "@/lib/api/errors";
 
-type Scope = "clubs" | "opportunities";
-type SavedView = {
-  id: string;
-  name: string;
-  params: string; // es: "?q=roma&country=IT&scope=clubs"
-  scope: Scope;
-  createdAt: number;
-};
+export const GET = withApiHandler(async (req: NextRequest) => {
+  const url = new URL(req.url);
+  const scope = url.searchParams.get("scope");
+  if (!scope) throw badRequest("Missing scope");
+  const data = await ViewsRepo.list(scope as any);
+  return NextResponse.json({ items: data });
+});
 
-// Mock in-memory (solo per dev/preview; in serverless può non persistere)
-const store = new Map<Scope, SavedView[]>();
-
-function list(scope?: Scope): SavedView[] {
-  if (!scope) {
-    const all: SavedView[] = [];
-    for (const arr of store.values()) all.push(...arr);
-    return all;
+export const POST = withApiHandler(async (req: NextRequest) => {
+  const body = await req.json();
+  if (!body.scope || !body.name || !body.filters) {
+    throw badRequest("Missing fields");
   }
-  return store.get(scope) ?? [];
-}
-
-function add(view: SavedView) {
-  const arr = store.get(view.scope) ?? [];
-  store.set(view.scope, [view, ...arr].slice(0, 50)); // hard cap
-}
-
-function del(scope: Scope, id: string) {
-  const arr = store.get(scope) ?? [];
-  store.set(
-    scope,
-    arr.filter((v) => v.id !== id)
-  );
-}
-
-export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const scope = searchParams.get("scope") as Scope | null;
-
-  const items = list(scope ?? undefined);
-  return NextResponse.json({ items });
-}
-
-export async function POST(req: NextRequest) {
-  let body: Partial<SavedView> | null = null;
-  try {
-    body = (await req.json()) as Partial<SavedView>;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
-  if (!body?.name || !body?.params || !body?.scope) {
-    return NextResponse.json(
-      { error: "Missing required fields: name, params, scope" },
-      { status: 400 }
-    );
-  }
-
-  const view: SavedView = {
-    id: crypto.randomUUID(),
-    name: String(body.name),
-    params: String(body.params),
-    scope: body.scope as Scope,
-    createdAt: Date.now(),
-  };
-
-  add(view);
+  const view = await ViewsRepo.create({
+    scope: body.scope,
+    name: body.name,
+    filters: body.filters,
+  });
   return NextResponse.json(view, { status: 201 });
-}
+});
 
-export async function DELETE(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const id = searchParams.get("id");
-  const scope = searchParams.get("scope") as Scope | null;
-
-  if (!id || !scope) {
-    return NextResponse.json(
-      { error: "Missing id or scope" },
-      { status: 400 }
-    );
-  }
-
-  del(scope, id);
-  return NextResponse.json({ ok: true }, { status: 200 });
-}
+export const DELETE = withApiHandler(async (req: NextRequest) => {
+  const url = new URL(req.url);
+  const id = url.searchParams.get("id");
+  if (!id) throw badRequest("Missing id");
+  await ViewsRepo.remove(id);
+  return NextResponse.json({ ok: true });
+});

--- a/components/auth/LogoutButton.tsx
+++ b/components/auth/LogoutButton.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { supabase } from "@/lib/supabase/client";
+
+export default function LogoutButton() {
+  async function handleLogout() {
+    await supabase.auth.signOut();
+    window.location.href = "/login";
+  }
+  return (
+    <button
+      onClick={handleLogout}
+      className="text-sm text-red-600 hover:underline"
+    >
+      Logout
+    </button>
+  );
+}

--- a/components/views/SavedViewsBar.tsx
+++ b/components/views/SavedViewsBar.tsx
@@ -1,86 +1,28 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { useToast } from "@/components/common/ToastProvider";
-import { buildQuery, parseFilters } from "@/lib/search/params";
-import { SavedView } from "@/lib/types/views";
+import { useSavedViews } from "@/lib/hooks/useSavedViews";
+import { parseFilters, buildQuery } from "@/lib/search/params";
 
-type Props = {
-  scope: "clubs" | "opportunities";
-};
+type Props = { scope: "clubs" | "opportunities" };
 
 export default function SavedViewsBar({ scope }: Props) {
   const sp = useSearchParams();
   const router = useRouter();
-  const { success, error } = useToast();
 
-  const [views, setViews] = useState<SavedView[]>([]);
-  const [loading, setLoading] = useState(false);
+  const { views, loading, create, remove } = useSavedViews(scope);
 
-  // carica viste salvate dal server
-  useEffect(() => {
-    const ac = new AbortController();
-    const run = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/views?scope=${scope}`, {
-          cache: "no-store",
-          signal: ac.signal,
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        setViews(data.items ?? []);
-      } catch (err) {
-        error("", {
-          title: "Errore caricamento viste",
-          description: err instanceof Error ? err.message : "Unknown error",
-        });
-      } finally {
-        setLoading(false);
-      }
-    };
-    run();
-    return () => ac.abort();
-  }, [scope, error]);
-
-  // salva una nuova vista
   async function handleSave() {
     const filters = parseFilters(sp);
     const name = prompt("Nome della vista salvata:");
     if (!name) return;
-    try {
-      const res = await fetch("/api/views", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ scope, name, filters }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const newView: SavedView = await res.json();
-      setViews((prev) => [...prev, newView]);
-      success("Vista salvata");
-    } catch (err) {
-      error("", { title: "Errore salvataggio", description: (err as Error).message });
-    }
+    await create({ scope, name, filters });
   }
 
-  // applica una vista
-  function handleApply(v: SavedView) {
-    const qs = buildQuery(v.filters, 1, 20);
+  function handleApply(filters: any) {
+    const qs = buildQuery(filters, 1, 20);
     router.push(`/${scope}?${qs}`);
-  }
-
-  // elimina una vista
-  async function handleDelete(id: string) {
-    if (!confirm("Eliminare questa vista?")) return;
-    try {
-      const res = await fetch(`/api/views?id=${id}`, { method: "DELETE" });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setViews((prev) => prev.filter((v) => v.id !== id));
-      success("Vista eliminata");
-    } catch (err) {
-      error("", { title: "Errore eliminazione", description: (err as Error).message });
-    }
   }
 
   return (
@@ -98,9 +40,9 @@ export default function SavedViewsBar({ scope }: Props) {
             key={v.id}
             className="flex items-center gap-1 px-2 py-1 border rounded-md bg-white shadow-sm text-sm"
           >
-            <button onClick={() => handleApply(v)}>{v.name}</button>
+            <button onClick={() => handleApply(v.filters)}>{v.name}</button>
             <button
-              onClick={() => handleDelete(v.id)}
+              onClick={() => remove(v.id)}
               className="text-red-500 text-xs ml-1"
             >
               ✕

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -1,0 +1,33 @@
+// lib/api/errors.ts
+export type ErrorCode =
+  | "BadRequest"
+  | "Unauthorized"
+  | "Forbidden"
+  | "NotFound"
+  | "Conflict"
+  | "Unprocessable"
+  | "TooManyRequests"
+  | "InternalError";
+
+export class AppError extends Error {
+  status: number;
+  code: ErrorCode;
+  details?: unknown;
+
+  constructor(message: string, status = 400, code: ErrorCode = "BadRequest", details?: unknown) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+// scorciatoie utili
+export const badRequest   = (msg = "Bad request", details?: unknown) => new AppError(msg, 400, "BadRequest", details);
+export const unauthorized = (msg = "Unauthorized") => new AppError(msg, 401, "Unauthorized");
+export const forbidden    = (msg = "Forbidden") => new AppError(msg, 403, "Forbidden");
+export const notFound     = (msg = "Not found") => new AppError(msg, 404, "NotFound");
+export const conflict     = (msg = "Conflict") => new AppError(msg, 409, "Conflict");
+export const unprocessable= (msg = "Unprocessable") => new AppError(msg, 422, "Unprocessable");
+export const tooMany      = (msg = "Too many requests") => new AppError(msg, 429, "TooManyRequests");
+export const internalErr  = (msg = "Internal server error", details?: unknown) => new AppError(msg, 500, "InternalError", details);

--- a/lib/api/handler.ts
+++ b/lib/api/handler.ts
@@ -1,0 +1,40 @@
+// lib/api/handler.ts
+import { NextRequest, NextResponse } from "next/server";
+import { AppError, internalErr } from "@/lib/api/errors";
+import { logger } from "@/lib/utils/logger";
+
+function getRequestId(req: NextRequest) {
+  return req.headers.get("x-request-id") || crypto.randomUUID();
+}
+
+export type ApiHandler = (req: NextRequest) => Promise<NextResponse>;
+
+export function withApiHandler(handler: ApiHandler): ApiHandler {
+  return async (req: NextRequest) => {
+    const started = Date.now();
+    const requestId = getRequestId(req);
+    const path = new URL(req.url).pathname;
+
+    try {
+      const res = await handler(req);
+      logger.info(`${req.method} ${path} -> ${res.status} (${Date.now() - started}ms)`, { requestId });
+      return res;
+    } catch (e: any) {
+      const err = e instanceof AppError ? e : internalErr(e?.message || "Unexpected error", e);
+      const payload = {
+        error: {
+          code: err.code,
+          message: err.message,
+          requestId,
+          path,
+          ts: new Date().toISOString(),
+        },
+      };
+
+      // log ricco solo lato server
+      logger.error(`${req.method} ${path} -> ${err.status}`, { requestId, code: err.code, message: err.message, stack: e?.stack });
+
+      return NextResponse.json(payload, { status: err.status });
+    }
+  };
+}

--- a/lib/data/clubs.ts
+++ b/lib/data/clubs.ts
@@ -1,0 +1,54 @@
+// lib/data/clubs.ts
+import type { Club } from "@/lib/types/entities";
+
+export type ClubFilters = {
+  q?: string; country?: string; status?: string; city?: string; from?: string; to?: string;
+};
+export type Page = { page: number; limit: number };
+export type ClubResult = { items: Club[]; total: number; hasMore: boolean };
+
+function inDateRange(d: string, from?: string, to?: string) {
+  if (from && d < from) return false;
+  if (to && d > to) return false;
+  return true;
+}
+
+/** ----- MOCK REPO ----- */
+const COUNTRIES: NonNullable<Club["country"]>[] = ["IT", "ES", "FR", "DE", "UK", "US"];
+const CITIES = ["Roma", "Milano", "Torino", "Madrid", "Paris", "Berlin", "London", "New York"];
+const STATUSES: NonNullable<Club["status"]>[] = ["active", "inactive", "archived"];
+const CLUB_NAMES = ["Atlético Carlentini", "Sporting Madrid", "Paris Étoile", "Berlin Adler", "London Lions", "New York Cosmos", "Torino Granata", "Milano Navigli"];
+const startDate = new Date(); startDate.setMonth(startDate.getMonth() - 9);
+const addDays = (d: Date, days: number) => { const x = new Date(d); x.setDate(x.getDate() + days); return x; };
+
+const MOCK: Club[] = Array.from({ length: 87 }).map((_, i) => ({
+  id: String(i + 1),
+  name: `${CLUB_NAMES[i % CLUB_NAMES.length]} ${i + 1}`,
+  country: COUNTRIES[i % COUNTRIES.length],
+  city: CITIES[i % CITIES.length],
+  status: STATUSES[i % STATUSES.length],
+  createdAt: addDays(startDate, i).toISOString().slice(0, 10),
+}));
+
+export const ClubsRepo = {
+  async search(filters: ClubFilters, { page, limit }: Page): Promise<ClubResult> {
+    const q = (filters.q ?? "").toLowerCase();
+    let arr = MOCK.slice();
+    if (q) arr = arr.filter(c => c.name.toLowerCase().includes(q) || (c.city ?? "").toLowerCase().includes(q));
+    if (filters.country) arr = arr.filter(c => (c.country ?? "") === filters.country);
+    if (filters.status) arr = arr.filter(c => (c.status ?? "") === filters.status);
+    if (filters.city) arr = arr.filter(c => (c.city ?? "").toLowerCase().includes(filters.city!.toLowerCase()));
+    if (filters.from || filters.to) arr = arr.filter(c => inDateRange(c.createdAt, filters.from, filters.to));
+
+    const total = arr.length;
+    const start = (page - 1) * limit;
+    const end = start + limit;
+    const items = arr.slice(start, end);
+    return { items, total, hasMore: end < total };
+  },
+
+  async searchDB(filters: ClubFilters, { page, limit }: Page): Promise<ClubResult> {
+    // TODO: rimpiazza con ORM/SQL; assicurati di restituire la stessa shape
+    return this.search(filters, { page, limit }); // fallback MOCK
+  },
+};

--- a/lib/data/opportunities.ts
+++ b/lib/data/opportunities.ts
@@ -1,0 +1,59 @@
+// lib/data/opportunities.ts
+import type { Opportunity } from "@/lib/types/entities";
+
+export type OppFilters = {
+  q?: string; role?: string; country?: string; status?: string; city?: string;
+  from?: string; to?: string;
+};
+export type Page = { page: number; limit: number };
+export type OppResult = { items: Opportunity[]; total: number; hasMore: boolean };
+
+function inDateRange(d: string, from?: string, to?: string) {
+  if (from && d < from) return false;
+  if (to && d > to) return false;
+  return true;
+}
+
+/** ----- MOCK REPO (attuale) ----- */
+const ROLES: NonNullable<Opportunity["role"]>[] = ["player", "coach", "staff", "scout", "director"];
+const COUNTRIES: NonNullable<Opportunity["country"]>[] = ["IT", "ES", "FR", "DE", "UK", "US"];
+const CITIES = ["Roma", "Milano", "Torino", "Madrid", "Paris", "Berlin", "London", "New York"];
+const STATUSES: NonNullable<Opportunity["status"]>[] = ["open", "closed", "draft", "archived"];
+const startDate = new Date(); startDate.setMonth(startDate.getMonth() - 6);
+const addDays = (d: Date, days: number) => { const x = new Date(d); x.setDate(x.getDate() + days); return x; };
+
+const MOCK: Opportunity[] = Array.from({ length: 123 }).map((_, i) => ({
+  id: String(i + 1),
+  title: `Opportunity ${i + 1} — ${ROLES[i % ROLES.length]} @ ${CITIES[i % CITIES.length]}`,
+  role: ROLES[i % ROLES.length],
+  country: COUNTRIES[i % COUNTRIES.length],
+  city: CITIES[i % CITIES.length],
+  status: STATUSES[i % STATUSES.length],
+  createdAt: addDays(startDate, i).toISOString().slice(0, 10),
+}));
+
+export const OpportunitiesRepo = {
+  /** MOCK implementation (default) */
+  async search(filters: OppFilters, { page, limit }: Page): Promise<OppResult> {
+    const q = (filters.q ?? "").toLowerCase();
+    let arr = MOCK.slice();
+    if (q) arr = arr.filter(o => o.title.toLowerCase().includes(q) || (o.city ?? "").toLowerCase().includes(q));
+    if (filters.role) arr = arr.filter(o => (o.role ?? "") === filters.role);
+    if (filters.country) arr = arr.filter(o => (o.country ?? "") === filters.country);
+    if (filters.status) arr = arr.filter(o => (o.status ?? "") === filters.status);
+    if (filters.city) arr = arr.filter(o => (o.city ?? "").toLowerCase().includes(filters.city!.toLowerCase()));
+    if (filters.from || filters.to) arr = arr.filter(o => inDateRange(o.createdAt, filters.from, filters.to));
+
+    const total = arr.length;
+    const start = (page - 1) * limit;
+    const end = start + limit;
+    const items = arr.slice(start, end);
+    return { items, total, hasMore: end < total };
+  },
+
+  /** DB implementation (stub): sostituisci con la tua query reale */
+  async searchDB(filters: OppFilters, { page, limit }: Page): Promise<OppResult> {
+    // TODO: rimpiazza con ORM/SQL; assicurati di restituire la stessa shape
+    return this.search(filters, { page, limit }); // fallback MOCK
+  },
+};

--- a/lib/data/views.ts
+++ b/lib/data/views.ts
@@ -1,0 +1,27 @@
+// lib/data/views.ts
+import { SavedView } from "@/lib/types/views";
+
+let MOCK: SavedView[] = []; // in-memory
+
+export const ViewsRepo = {
+  async list(scope: SavedView["scope"]): Promise<SavedView[]> {
+    // TODO: sostituire con query DB
+    return MOCK.filter(v => v.scope === scope);
+  },
+
+  async create(view: Omit<SavedView, "id" | "createdAt">): Promise<SavedView> {
+    // TODO: sostituire con insert DB
+    const newView: SavedView = {
+      ...view,
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+    };
+    MOCK.push(newView);
+    return newView;
+  },
+
+  async remove(id: string): Promise<void> {
+    // TODO: sostituire con delete DB
+    MOCK = MOCK.filter(v => v.id !== id);
+  },
+};

--- a/lib/hooks/useSavedViews.ts
+++ b/lib/hooks/useSavedViews.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SavedView } from "@/lib/types/views";
+import { useToast } from "@/components/common/ToastProvider";
+
+export function useSavedViews(scope: "clubs" | "opportunities") {
+  const { success, error } = useToast();
+  const [views, setViews] = useState<SavedView[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // carica all’avvio
+  useEffect(() => {
+    const ac = new AbortController();
+    const run = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/views?scope=${scope}`, {
+          cache: "no-store",
+          signal: ac.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        setViews(data.items ?? []);
+      } catch (err) {
+        error("", { title: "Errore caricamento viste", description: (err as Error).message });
+      } finally {
+        setLoading(false);
+      }
+    };
+    run();
+    return () => ac.abort();
+  }, [scope, error]);
+
+  async function create(view: Omit<SavedView, "id" | "createdAt">) {
+    try {
+      const res = await fetch("/api/views", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(view),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const newView: SavedView = await res.json();
+      setViews((prev) => [...prev, newView]);
+      success("Vista salvata");
+      return newView;
+    } catch (err) {
+      error("", { title: "Errore salvataggio vista", description: (err as Error).message });
+    }
+  }
+
+  async function remove(id: string) {
+    try {
+      const res = await fetch(`/api/views?id=${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setViews((prev) => prev.filter((v) => v.id !== id));
+      success("Vista eliminata");
+    } catch (err) {
+      error("", { title: "Errore eliminazione vista", description: (err as Error).message });
+    }
+  }
+
+  return { views, loading, create, remove };
+}

--- a/lib/hooks/useSavedViews.ts
+++ b/lib/hooks/useSavedViews.ts
@@ -3,6 +3,13 @@
 import { useEffect, useState } from "react";
 import { SavedView } from "@/lib/types/views";
 import { useToast } from "@/components/common/ToastProvider";
+import { createClient } from "@supabase/supabase-js";
+
+// Supabase client lato client (usa le NEXT_PUBLIC_* che hai già in .env.local)
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+);
 
 export function useSavedViews(scope: "clubs" | "opportunities") {
   const { success, error } = useToast();
@@ -19,11 +26,21 @@ export function useSavedViews(scope: "clubs" | "opportunities") {
           cache: "no-store",
           signal: ac.signal,
         });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) {
+          // Se hai 401 perché non loggato, non mostrare errore rumoroso
+          if (res.status === 401) {
+            setViews([]);
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
         const data = await res.json();
         setViews(data.items ?? []);
       } catch (err) {
-        error("", { title: "Errore caricamento viste", description: (err as Error).message });
+        error("", {
+          title: "Errore caricamento viste",
+          description: (err as Error).message,
+        });
       } finally {
         setLoading(false);
       }
@@ -32,20 +49,37 @@ export function useSavedViews(scope: "clubs" | "opportunities") {
     return () => ac.abort();
   }, [scope, error]);
 
+  // crea una nuova vista: aggiunge automaticamente user_id dell’utente loggato
   async function create(view: Omit<SavedView, "id" | "createdAt">) {
     try {
+      const { data, error: authError } = await supabase.auth.getUser();
+      if (authError) throw authError;
+      const userId = data?.user?.id;
+      if (!userId) {
+        error("", {
+          title: "Non sei autenticato",
+          description: "Effettua il login per salvare una vista.",
+        });
+        return;
+      }
+
       const res = await fetch("/api/views", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(view),
+        body: JSON.stringify({ ...view, user_id: userId }), // 👈 passiamo user_id richiesto dalla route
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      // La tua route POST ritorna l’oggetto creato (SavedView)
       const newView: SavedView = await res.json();
       setViews((prev) => [...prev, newView]);
       success("Vista salvata");
       return newView;
     } catch (err) {
-      error("", { title: "Errore salvataggio vista", description: (err as Error).message });
+      error("", {
+        title: "Errore salvataggio vista",
+        description: (err as Error).message,
+      });
     }
   }
 
@@ -56,7 +90,10 @@ export function useSavedViews(scope: "clubs" | "opportunities") {
       setViews((prev) => prev.filter((v) => v.id !== id));
       success("Vista eliminata");
     } catch (err) {
-      error("", { title: "Errore eliminazione vista", description: (err as Error).message });
+      error("", {
+        title: "Errore eliminazione vista",
+        description: (err as Error).message,
+      });
     }
   }
 

--- a/lib/hooks/useSupabaseAuth.ts
+++ b/lib/hooks/useSupabaseAuth.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+
+export function useSupabaseAuth() {
+  const [user, setUser] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    const run = async () => {
+      const { data } = await supabase.auth.getUser();
+      if (mounted) setUser(data.user ?? null);
+      setLoading(false);
+    };
+    run();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) setUser(session?.user ?? null);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return { user, loading };
+}

--- a/lib/search/params.ts
+++ b/lib/search/params.ts
@@ -1,0 +1,87 @@
+// lib/search/params.ts
+import { NormalizedFilters, SearchFilters } from "@/lib/types/entities";
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+// Chiavi dei filtri supportate e il loro ordine (stabile per SavedViews/link)
+export const FILTER_KEYS: (keyof SearchFilters)[] = [
+  "q", "role", "country", "status", "city", "from", "to",
+];
+
+type SPInput =
+  | URLSearchParams
+  | Readonly<URLSearchParams>
+  | Record<string, string | string[] | undefined>;
+
+/** Utility */
+const isNonEmpty = (v: unknown): v is string => typeof v === "string" && v.trim() !== "";
+const clampInt = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+
+/** Estrae un valore singolo dai params (accetta array e record) */
+function getOne(sp: SPInput, key: string): string | undefined {
+  if (sp instanceof URLSearchParams) return sp.get(key) ?? undefined;
+  const raw = (sp as any)?.[key];
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw)) return raw[0];
+  return undefined;
+}
+
+/** Page/Limit */
+export function parsePage(sp: SPInput): number {
+  const raw = getOne(sp, "page");
+  const n = raw ? parseInt(raw, 10) : DEFAULT_PAGE;
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_PAGE;
+}
+export function parseLimit(sp: SPInput): number {
+  const raw = getOne(sp, "limit");
+  const n = raw ? parseInt(raw, 10) : DEFAULT_LIMIT;
+  return clampInt(Number.isFinite(n) && n > 0 ? n : DEFAULT_LIMIT, 1, MAX_LIMIT);
+}
+
+/** Normalizza i filtri (stringhe vuote -> undefined, trimming) */
+export function parseFilters(sp: SPInput): NormalizedFilters {
+  const out = {} as NormalizedFilters;
+  for (const k of FILTER_KEYS) {
+    const v = getOne(sp, k);
+    out[k] = isNonEmpty(v) ? v!.trim() : undefined;
+  }
+  return out;
+}
+
+/** Costruisce una query string consistente (solo chiavi valorizzate) */
+export function buildQuery(filters: SearchFilters, page?: number, limit?: number): string {
+  const p = new URLSearchParams();
+  const _page = page ?? DEFAULT_PAGE;
+  const _limit = limit ?? DEFAULT_LIMIT;
+  p.set("page", String(_page));
+  p.set("limit", String(clampInt(_limit, 1, MAX_LIMIT)));
+  for (const k of FILTER_KEYS) {
+    const v = filters[k];
+    if (isNonEmpty(v)) p.set(k, v as string);
+  }
+  return p.toString();
+}
+
+/** Unisci lo stato attuale con override e ritorna la query string */
+export function mergeQuery(
+  current: SPInput,
+  overrides: Partial<SearchFilters & { page?: number; limit?: number }>
+): string {
+  const filters = parseFilters(current);
+  const page = overrides.page ?? parsePage(current);
+  const limit = overrides.limit ?? parseLimit(current);
+
+  // Applica override dei filtri
+  const merged: SearchFilters = {};
+  for (const k of FILTER_KEYS) {
+    const ov = overrides[k as keyof SearchFilters];
+    merged[k as keyof SearchFilters] = isNonEmpty(ov) ? (ov as string) : (filters[k] ?? undefined);
+  }
+  // Se cambio un filtro, riporto pagina a 1 (comportamento comune)
+  const changedAnyFilter = FILTER_KEYS.some((k) => overrides[k as keyof SearchFilters] !== undefined);
+  const nextPage = changedAnyFilter ? DEFAULT_PAGE : page;
+
+  return buildQuery(merged, nextPage, limit);
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+
+export const supabase = createBrowserClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/lib/types/entities.ts
+++ b/lib/types/entities.ts
@@ -1,0 +1,47 @@
+// lib/types/entities.ts
+
+// --- Entità ---
+export type OpportunityRole = "player" | "coach" | "staff" | "scout" | "director";
+export type CountryCode = "IT" | "ES" | "FR" | "DE" | "UK" | "US";
+export type OpportunityStatus = "open" | "closed" | "draft" | "archived";
+export type ClubStatus = "active" | "inactive" | "archived";
+
+export type Opportunity = {
+  id: string;
+  title: string;
+  role?: OpportunityRole;
+  country?: CountryCode;
+  city?: string;
+  status?: OpportunityStatus;
+  createdAt: string; // YYYY-MM-DD
+};
+
+export type Club = {
+  id: string;
+  name: string;
+  country?: CountryCode;
+  city?: string;
+  status?: ClubStatus;
+  createdAt: string; // YYYY-MM-DD
+};
+
+// --- Filtri comuni (coerenti con SavedViews/URL) ---
+export type SearchFilters = {
+  q?: string;
+  role?: string;        // compat: presente su Opportunities; accettato/ignorato su Clubs
+  country?: string;
+  status?: string;
+  city?: string;
+  from?: string;        // YYYY-MM-DD
+  to?: string;          // YYYY-MM-DD
+};
+
+// Versione “normalizzata” (stringhe vuote -> undefined)
+export type NormalizedFilters = Required<Record<keyof SearchFilters, string | undefined>>;
+
+// --- Paginazione ---
+export type Paginated<T> = {
+  items: T[];
+  total: number;
+  hasMore: boolean;
+};

--- a/lib/types/views.ts
+++ b/lib/types/views.ts
@@ -1,0 +1,10 @@
+// lib/types/views.ts
+import { SearchFilters } from "@/lib/types/entities";
+
+export type SavedView = {
+  id: string;
+  scope: "opportunities" | "clubs";   // identifica la sezione
+  name: string;                       // nome della vista
+  filters: SearchFilters;             // i filtri serializzati
+  createdAt: string;                  // ISO date
+};

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -1,0 +1,17 @@
+// lib/utils/logger.ts
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+const envLevel = (process.env.LOG_LEVEL as LogLevel) || "info";
+const current = LEVELS.indexOf(envLevel);
+
+function shouldLog(level: LogLevel) {
+  return LEVELS.indexOf(level) >= current;
+}
+
+export const logger = {
+  debug: (...a: any[]) => shouldLog("debug") && console.debug("[debug]", ...a),
+  info:  (...a: any[]) => shouldLog("info")  && console.info("[info] ", ...a),
+  warn:  (...a: any[]) => shouldLog("warn")  && console.warn("[warn] ", ...a),
+  error: (...a: any[]) => shouldLog("error") && console.error("[error]", ...a),
+};


### PR DESCRIPTION
## Cosa include
- **16A**: `/api/opportunities` stub in-memory con filtri, `total`, `hasMore`
- **16B**: `/api/clubs` stub in-memory con filtri, `total`, `hasMore`
- **16C**: tipi condivisi e helpers query/filtri/paginazione (`lib/types`, `lib/search`);
  pagina Clubs aggiornata a usare gli helpers

## Note di test
- Verificati SavedViews (salva/applica/elimina, copia link)
- Pager: rispetto `hasMore`; ResultBadge mostra `total`
- Query string uniforme tra pagine

## Prossimi step
- Allineare **Opportunities** agli helpers (facoltativo)
- Sostituire stub con query DB mantenendo la stessa forma di risposta
