### PR TITLE
feat/club applicants and notes

### DIFF
--- a/app/(dashboard)/club/profile/page.tsx
+++ b/app/(dashboard)/club/profile/page.tsx
@@ -7,6 +7,18 @@ import { supabaseBrowser } from '@/lib/supabaseBrowser';
 
 const BIO_WORD_LIMIT = 100;
 
+// slugify basilare con normalizzazione accenti
+function slugify(s: string) {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
 function countWords(s: string) {
   return s.trim().split(/\s+/).filter(Boolean).length;
 }
@@ -23,6 +35,8 @@ export default function ClubProfilePage() {
   const [name, setName] = useState('');
   const [bio, setBio] = useState('');
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
+
+  const [publicSlug, setPublicSlug] = useState<string | null>(null);
 
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -48,7 +62,8 @@ export default function ClubProfilePage() {
         return;
       }
       if (!user) {
-        router.push('/login');
+        // coerente col middleware/UX del progetto
+        router.push('/onboarding');
         return;
       }
       setUserId(user.id);
@@ -65,6 +80,7 @@ export default function ClubProfilePage() {
         return;
       }
 
+      let current = existing;
       if (!existing) {
         const { data: inserted, error: insErr } = await supabase
           .from('clubs')
@@ -77,16 +93,23 @@ export default function ClubProfilePage() {
           setLoading(false);
           return;
         }
+        current = inserted;
+      }
 
-        setClubId(inserted.id);
-        setName(inserted.name ?? '');
-        setBio(inserted.bio ?? '');
-        setLogoUrl(inserted.logo_url);
-      } else {
-        setClubId(existing.id);
-        setName(existing.name ?? '');
-        setBio(existing.bio ?? '');
-        setLogoUrl(existing.logo_url);
+      setClubId(current!.id);
+      setName(current!.name ?? '');
+      setBio(current!.bio ?? '');
+      setLogoUrl(current!.logo_url);
+
+      // Recupera slug pubblico dall'API stub (B1) con fallback a slugify(name)
+      try {
+        const r = await fetch('/api/clubs/me', { cache: 'no-store', credentials: 'include' });
+        const dj = await r.json().catch(() => ({}));
+        const apiSlug: string | undefined = dj?.club?.slug;
+        if (apiSlug) setPublicSlug(String(apiSlug));
+        else if (current!.name) setPublicSlug(slugify(String(current!.name)));
+      } catch {
+        if (current!.name) setPublicSlug(slugify(String(current!.name)));
       }
 
       setLoading(false);
@@ -194,6 +217,9 @@ export default function ClubProfilePage() {
       const { error: updErr } = await supabase.from('clubs').update({ name, bio }).eq('id', clubId);
       if (updErr) throw updErr;
 
+      // aggiorna slug suggerito se mancava
+      if (!publicSlug && name) setPublicSlug(slugify(name));
+
       setOkMsg('Profilo salvato.');
     } catch (e: any) {
       setError(e?.message || 'Errore nel salvataggio');
@@ -206,105 +232,142 @@ export default function ClubProfilePage() {
 
   if (loading) {
     return (
-      <div className="max-w-3xl mx-auto p-6">
-        <h1 className="text-2xl font-semibold">Profilo Club</h1>
-        <p className="mt-4">Caricamento…</p>
-      </div>
+      <main className="container mx-auto px-4 py-6">
+        <div className="rounded-xl border bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+          <h1 className="text-lg font-semibold">Il tuo profilo club</h1>
+          <p className="mt-2 text-sm text-neutral-500">Caricamento…</p>
+        </div>
+      </main>
     );
   }
 
   return (
-    <div className="max-w-3xl mx-auto p-6 space-y-8">
-      <h1 className="text-2xl font-semibold">Profilo Club</h1>
+    <main className="container mx-auto px-4 py-6">
+      <div className="rounded-xl border bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <h1 className="text-lg font-semibold">Il tuo profilo club</h1>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+          Modifica le informazioni del club e gestisci il logo.
+        </p>
 
-      {error && (
-        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>
-      )}
-      {okMsg && (
-        <div className="rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-700">{okMsg}</div>
-      )}
-
-      {/* LOGO */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium">Logo</h2>
-        <div className="flex items-center gap-4">
-          <div className="relative h-24 w-24 overflow-hidden rounded-md border bg-white">
-            {logoUrl ? (
-              <Image
-                src={logoUrl}
-                alt="Logo club"
-                fill
-                className="object-cover"
-                sizes="96px"
-                unoptimized
-                priority={false}
-              />
-            ) : (
-              <div className="flex h-full w-full items-center justify-center text-gray-400">Nessun logo</div>
-            )}
+        {error && (
+          <div className="mt-4 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+            {error}
           </div>
+        )}
+        {okMsg && (
+          <div className="mt-4 rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-700 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-300">
+            {okMsg}
+          </div>
+        )}
 
-          <div className="flex flex-col gap-2">
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/png,image/jpeg"
-              onChange={(e) => onPickLogo(e.target.files?.[0] ?? null)}
-              disabled={uploading}
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={uploadLogo}
-                disabled={!logoFile || uploading}
-                className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-50"
-              >
-                {uploading ? 'Carico…' : 'Carica logo'}
-              </button>
-              {logoFile && <span className="text-sm text-gray-600">File: {logoFile.name}</span>}
+        {/* LOGO */}
+        <section className="mt-6 space-y-4">
+          <h2 className="text-lg font-medium">Logo</h2>
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="relative h-24 w-24 overflow-hidden rounded-md border bg-white">
+              {logoUrl ? (
+                <Image
+                  src={logoUrl}
+                  alt="Logo club"
+                  fill
+                  className="object-cover"
+                  sizes="96px"
+                  unoptimized
+                  priority={false}
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-gray-400">Nessun logo</div>
+              )}
             </div>
-            <p className="text-xs text-gray-500">Suggerito: PNG/JPG quadrato ≤ 2MB.</p>
+
+            <div className="flex flex-col gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg"
+                onChange={(e) => onPickLogo(e.target.files?.[0] ?? null)}
+                disabled={uploading}
+              />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={uploadLogo}
+                  disabled={!logoFile || uploading}
+                  className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-50"
+                >
+                  {uploading ? 'Carico…' : 'Carica logo'}
+                </button>
+                {logoFile && <span className="text-sm text-gray-600">File: {logoFile.name}</span>}
+              </div>
+              <p className="text-xs text-gray-500">Suggerito: PNG/JPG quadrato ≤ 2MB.</p>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* DATI CLUB */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium">Dati</h2>
-        <div className="space-y-2">
-          <label className="block text-sm font-medium">Nome Club</label>
-          <input
-            className="w-full rounded-md border px-3 py-2"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Es. ASD Example"
-          />
-        </div>
-
-        <div className="space-y-1">
-          <label className="block text-sm font-medium">Bio</label>
-          <textarea
-            className="w-full rounded-md border px-3 py-2"
-            rows={5}
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-            placeholder="Racconta qualcosa sul club…"
-          />
-          <div className="text-xs">
-            Parole: {bioWords}/{BIO_WORD_LIMIT}{' '}
-            {bioWords > BIO_WORD_LIMIT && <span className="text-red-600">(limite superato)</span>}
+        {/* DATI CLUB */}
+        <section className="mt-8 space-y-4">
+          <h2 className="text-lg font-medium">Dati</h2>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium">Nome Club</label>
+            <input
+              className="w-full rounded-md border px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Es. ASD Example"
+            />
           </div>
-        </div>
 
-        <button
-          type="button"
-          onClick={saveProfile}
-          disabled={saving}
-          className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-50"
-        >
-          {saving ? 'Salvo…' : 'Salva profilo'}
-        </button>
-      </section>
-    </div>
+          <div className="space-y-1">
+            <label className="block text-sm font-medium">Bio</label>
+            <textarea
+              className="w-full rounded-md border px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+              rows={5}
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              placeholder="Racconta qualcosa sul club…"
+            />
+            <div className="text-xs">
+              Parole: {bioWords}/{BIO_WORD_LIMIT}{' '}
+              {bioWords > BIO_WORD_LIMIT && <span className="text-red-600">(limite superato)</span>}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={saveProfile}
+              disabled={saving}
+              className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-50"
+            >
+              {saving ? 'Salvo…' : 'Salva profilo'}
+            </button>
+
+            {/* Link utili (profilo pubblico / opportunità / candidature) */}
+            <a
+              href={publicSlug ? `/c/${publicSlug}` : '#'}
+              className="rounded-md border px-3 py-2 text-sm font-semibold hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800 disabled:opacity-50"
+              aria-disabled={!publicSlug}
+              onClick={(e) => {
+                if (!publicSlug) e.preventDefault();
+              }}
+            >
+              Apri profilo pubblico
+            </a>
+            <a
+              href="/opportunities/new"
+              className="rounded-md border px-3 py-2 text-sm font-semibold hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
+              + Pubblica opportunità
+            </a>
+            <a
+              href="/club/applicants"
+              className="rounded-md border px-3 py-2 text-sm font-semibold hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
+              Candidature ricevute
+            </a>
+          </div>
+        </section>
+      </div>
+    </main>
   );
 }

--- a/app/(dashboard)/feed/page.tsx
+++ b/app/(dashboard)/feed/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import FeedLatest from '@/components/feed/FeedLatest';
 import WhoToFollow from '@/components/feed/WhoToFollow';
+import Composer from '@/components/feed/Composer';
+import FeedPosts from '@/components/feed/FeedPosts';
 
 type Role = 'club' | 'athlete' | 'guest';
 
@@ -70,42 +72,14 @@ export default function FeedPage() {
 
         {/* CENTRO */}
         <section className="lg:col-span-6 flex flex-col gap-6">
-          {/* Composer semplificato (placeholder) */}
-          <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
-            <div className="mb-3 text-sm text-neutral-500">Condividi un aggiornamento</div>
-            <textarea
-              className="w-full rounded-xl border px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
-              rows={3}
-              placeholder="Scrivi qualcosa…"
-            />
-            <div className="mt-3 flex justify-end">
-              <button
-                className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
-                disabled
-              >
-                Pubblica (coming soon)
-              </button>
-            </div>
-          </div>
+          {/* Composer attivo */}
+          <Composer />
+
+          {/* Post recenti (API stub) */}
+          <FeedPosts />
 
           {/* 🔴 DATI REALI: Ultime opportunità */}
           <FeedLatest />
-
-          {/* Post di un club (placeholder) */}
-          <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
-            <div className="font-medium">Post di un club</div>
-            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-              Foto allenamento prima squadra…
-            </p>
-            <div className="mt-3 flex gap-2">
-              <button className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800" disabled>
-                Mi piace
-              </button>
-              <button className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800" disabled>
-                Commenta
-              </button>
-            </div>
-          </div>
         </section>
 
         {/* DESTRA */}

--- a/app/(dashboard)/opportunities/page.tsx
+++ b/app/(dashboard)/opportunities/page.tsx
@@ -1,12 +1,235 @@
 'use client';
 
-import { Suspense } from 'react';
-import OpportunitiesClient from './OpportunitiesClient';
+import { useEffect, useMemo, useState } from 'react';
+import OpportunitiesFilterBar, { OppFilters } from '@/components/opportunities/OpportunitiesFilterBar';
+import OpportunityActions from '@/components/opportunities/OpportunityActions';
+
+type RawOpportunity = any;
+
+type NormalizedOpp = {
+  id: string;
+  title: string;
+  clubId?: string;
+  clubName?: string;
+  city?: string;
+  sport?: string;
+  roleName?: string;
+  createdAt?: string; // ISO
+};
+
+// Normalizzatore robusto (adatta payload eterogenei)
+function normalize(raw: RawOpportunity): NormalizedOpp | null {
+  if (!raw) return null;
+
+  const id = String(
+    raw.id ?? raw.uuid ?? raw.slug ?? raw.opportunityId ?? raw._id ?? raw.key ?? ''
+  ).trim();
+  if (!id) return null;
+
+  const title = String(
+    raw.title ?? raw.name ?? raw.roleTitle ?? raw.role ?? raw.position ?? 'Opportunità'
+  ).trim();
+
+  const clubObj = raw.club ?? raw.company ?? raw.org ?? {};
+  const clubId = clubObj.id ?? clubObj.uuid ?? raw.clubId ?? raw.companyId ?? undefined;
+  const clubName = clubObj.name ?? clubObj.title ?? raw.clubName ?? raw.companyName ?? undefined;
+
+  const city = raw.city ?? raw.location?.city ?? raw.place?.city ?? raw.geo?.city ?? undefined;
+
+  const sport = raw.sport ?? raw.sport_name ?? raw.category ?? undefined;
+  const roleName = raw.roleName ?? raw.role ?? raw.position ?? undefined;
+
+  const createdAtRaw =
+    raw.createdAt ?? raw.created_at ?? raw.publishedAt ?? raw.published_at ?? raw.inserted_at ?? undefined;
+  const createdAt = createdAtRaw ? new Date(createdAtRaw).toISOString() : undefined;
+
+  return {
+    id,
+    title,
+    clubId: clubId ? String(clubId) : undefined,
+    clubName,
+    city,
+    sport,
+    roleName,
+    createdAt,
+  };
+}
+
+const PAGE_SIZE = 10;
 
 export default function OpportunitiesPage() {
+  const [filters, setFilters] = useState<OppFilters>({});
+  const [items, setItems] = useState<NormalizedOpp[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [page, setPage] = useState(1); // client-side paging su lista caricata
+
+  useEffect(() => {
+    (async () => {
+      await load(filters);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function load(f: OppFilters) {
+    try {
+      setLoading(true);
+      setErr(null);
+      setPage(1);
+
+      const qs = new URLSearchParams();
+      if (f.role) qs.set('role', f.role);
+      if (f.city) qs.set('city', f.city);
+
+      // 1) prova endpoint filtro (se esiste)
+      let res = await fetch(`/api/opportunities/filter?${qs.toString()}`, {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+
+      // 2) fallback endpoint generico (se /filter non esiste o 404)
+      if (!res.ok) {
+        res = await fetch('/api/opportunities', {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+      }
+
+      const data = await res.json().catch(() => ({}));
+      const rawList: RawOpportunity[] = Array.isArray(data?.items)
+        ? data.items
+        : Array.isArray(data)
+        ? data
+        : Array.isArray(data?.data)
+        ? data.data
+        : [];
+
+      // Se endpoint generico, applichiamo filtro lato client (best effort)
+      let normalized = rawList.map(normalize).filter(Boolean) as NormalizedOpp[];
+      if (res.url.endsWith('/api/opportunities')) {
+        normalized = normalized.filter((it) => {
+          const okRole = f.role
+            ? (it.roleName || it.title || '').toLowerCase().includes(f.role!.toLowerCase())
+            : true;
+          const okCity = f.city ? (it.city || '').toLowerCase().includes(f.city!.toLowerCase()) : true;
+          return okRole && okCity;
+        });
+      }
+
+      // Ordina dal più recente se disponibile
+      normalized.sort((a, b) => {
+        const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return tb - ta;
+      });
+
+      setItems(normalized);
+      setFilters(f);
+    } catch (e: any) {
+      setErr(e?.message || 'Errore inatteso');
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const visible = useMemo(() => {
+    const end = page * PAGE_SIZE;
+    return items.slice(0, end);
+  }, [items, page]);
+
+  const canLoadMore = visible.length < items.length;
+
   return (
-    <Suspense fallback={<div className="p-6">Caricamento…</div>}>
-      <OpportunitiesClient />
-    </Suspense>
+    <main className="container mx-auto px-4 py-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <section className="lg:col-span-8 flex flex-col gap-6">
+          {/* Filtri */}
+          <OpportunitiesFilterBar
+            initial={filters}
+            onApply={(f) => load(f)}
+          />
+
+          {/* Lista opportunità */}
+          <section className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">
+                🔍 Risultati Opportunità
+              </h3>
+              <div className="text-xs text-neutral-500">
+                {loading ? 'Caricamento…' : `${items.length} risultati`}
+              </div>
+            </div>
+
+            {loading ? (
+              <ul className="space-y-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <li key={i} className="rounded-lg border p-3 dark:border-neutral-800">
+                    <div className="h-4 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+                    <div className="mt-2 h-3 w-1/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+                    <div className="mt-3 h-8 w-52 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+                  </li>
+                ))}
+              </ul>
+            ) : err ? (
+              <div className="rounded-lg border border-dashed p-4 text-sm text-red-600 dark:border-neutral-800">
+                Errore: {err}
+              </div>
+            ) : visible.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-4 text-sm text-neutral-500 dark:border-neutral-800">
+                Nessuna opportunità trovata. Prova a modificare i filtri.
+              </div>
+            ) : (
+              <>
+                <ul className="space-y-4">
+                  {visible.map((it) => (
+                    <li key={it.id} className="rounded-lg border p-3 dark:border-neutral-800">
+                      <div className="mb-1 text-sm font-medium">{it.title}</div>
+                      <div className="text-xs text-neutral-500">
+                        {it.clubName ? `${it.clubName}` : 'Club'}
+                        {it.city ? ` · ${it.city}` : ''}
+                        {it.roleName ? ` · ${it.roleName}` : ''}
+                        {it.sport ? ` · ${it.sport}` : ''}
+                        {it.createdAt ? ` · ${new Date(it.createdAt).toLocaleDateString()}` : ''}
+                      </div>
+
+                      <OpportunityActions
+                        opportunityId={it.id}
+                        clubId={it.clubId}
+                        clubName={it.clubName}
+                        compact
+                        className="mt-3"
+                      />
+                    </li>
+                  ))}
+                </ul>
+
+                {canLoadMore && (
+                  <div className="mt-4">
+                    <button
+                      type="button"
+                      onClick={() => setPage((p) => p + 1)}
+                      className="w-full rounded-xl border px-3 py-2 text-sm font-semibold hover:bg-neutral-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                    >
+                      Mostra altri
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        </section>
+
+        {/* Sidebar destra (facoltativa) */}
+        <aside className="hidden xl:col-span-4 xl:block">
+          <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+            <h3 className="mb-2 text-sm font-semibold text-neutral-700 dark:text-neutral-200">Suggerimenti</h3>
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">
+              A breve qui compariranno alert salvati, ricerche recenti e suggerimenti personalizzati.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </main>
   );
 }

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -1,15 +1,72 @@
 'use client';
 
-import ProfileEditForm from '@/components/profiles/ProfileEditForm';
+import { useEffect, useState } from 'react';
 
-export default function ProfilePage() {
+type Me = { id: string; handle: string; name: string };
+
+export default function AthletePrivateProfilePage() {
+  const [me, setMe] = useState<Me | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setErr(null);
+        const r = await fetch('/api/athletes/me', { cache: 'no-store', credentials: 'include' });
+        const dj = await r.json().catch(() => ({}));
+        if (!r.ok || !dj?.athlete) throw new Error(dj?.error || 'Impossibile recuperare il profilo');
+        setMe(dj.athlete);
+      } catch (e: any) {
+        setErr(e?.message || 'Errore inatteso');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
   return (
-    <div className="p-4 md:p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Il mio profilo atleta</h1>
-      <p className="text-sm text-gray-600">
-        Aggiorna i tuoi dati per migliorare il matching con club e opportunità.
-      </p>
-      <ProfileEditForm />
-    </div>
+    <main className="container mx-auto px-4 py-6">
+      <div className="rounded-xl border bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <h1 className="text-lg font-semibold">Il tuo profilo atleta</h1>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">Modifica e anteprima del profilo.</p>
+
+        {loading ? (
+          <div className="mt-4 h-16 w-1/2 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        ) : err ? (
+          <div className="mt-4 rounded-lg border border-dashed p-3 text-sm text-red-600 dark:border-neutral-800">
+            Errore: {err}
+          </div>
+        ) : me ? (
+          <div className="mt-4 space-y-4">
+            <div className="text-sm">
+              <div className="font-medium">{me.name}</div>
+              <div className="text-neutral-500">
+                Handle pubblico: <code>/{`u/${me.handle}`}</code>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <a
+                href={`/u/${me.handle}`}
+                className="rounded-md border px-3 py-2 text-sm font-semibold hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+              >
+                Apri profilo pubblico
+              </a>
+              <a
+                href="/feed"
+                className="rounded-md border px-3 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+              >
+                Torna al feed
+              </a>
+            </div>
+
+            <div className="mt-6 rounded-lg border border-dashed p-4 text-sm text-neutral-500 dark:border-neutral-800">
+              Editor dettagli atleta in arrivo (ruolo, piede, altezza, peso, link video).
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </main>
   );
 }

--- a/app/api/athletes/[handle]/posts/route.ts
+++ b/app/api/athletes/[handle]/posts/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+type Post = {
+  id: string;
+  text: string;
+  createdAt: string; // ISO
+};
+
+const POSTS: Record<string, Post[]> = {
+  'davide-bianchi': [
+    { id: 'p_db_1', text: 'Vittoria 2-1 in amichevole! ⚽️', createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString() },
+    { id: 'p_db_2', text: 'Seduta di forza + rifinitura al tiro.', createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString() },
+  ],
+  'marco-greco': [
+    { id: 'p_mg_1', text: 'Allenamento ad alta intensità ✅', createdAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString() },
+  ],
+};
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ handle: string }> },
+) {
+  const { handle } = await context.params;
+  const items = POSTS[(handle || '').toLowerCase()] ?? [];
+  // Ordina dal più recente
+  items.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  return NextResponse.json({ items });
+}

--- a/app/api/athletes/[handle]/route.ts
+++ b/app/api/athletes/[handle]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+type Athlete = {
+  id: string;          // usato nel follow cookie
+  handle: string;      // usato nel path pubblico
+  name: string;
+  age?: number;
+  position?: string;   // es. ATT, CC, POR...
+  city?: string;
+  sport?: string;
+  avatarUrl?: string;
+  coverUrl?: string;
+  about?: string;
+  followers?: number;
+};
+
+const ATHLETES: Record<string, Athlete> = {
+  'davide-bianchi': {
+    id: 'ath-davide-bianchi',
+    handle: 'davide-bianchi',
+    name: 'Davide Bianchi',
+    age: 21,
+    position: 'ATT',
+    city: 'Siracusa',
+    sport: 'Calcio',
+    avatarUrl: '',
+    coverUrl: '',
+    about: 'Attaccante classe 2004, rapido sul breve, buon senso del gol.',
+    followers: 420,
+  },
+  'marco-greco': {
+    id: 'ath-marco-greco',
+    handle: 'marco-greco',
+    name: 'Marco Greco',
+    age: 22,
+    position: 'ATT',
+    city: 'Catania',
+    sport: 'Calcio',
+    avatarUrl: '',
+    coverUrl: '',
+    about: 'Punta centrale strutturata, gioco spalle alla porta.',
+    followers: 380,
+  },
+};
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ handle: string }> },
+) {
+  const { handle } = await context.params; // Next 15.5: Promise
+  const key = (handle || '').toLowerCase();
+  const athlete = ATHLETES[key];
+
+  if (!athlete) {
+    return NextResponse.json({ ok: false, error: 'Atleta non trovato' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true, athlete });
+}

--- a/app/api/athletes/me/route.ts
+++ b/app/api/athletes/me/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  // TODO: derivare da whoami/DB. Stub sicuro per dev:
+  const athlete = {
+    id: 'ath-davide-bianchi',
+    handle: 'davide-bianchi',
+    name: 'Davide Bianchi',
+  };
+  return NextResponse.json({ ok: true, athlete });
+}

--- a/app/api/clubs/[slug]/opportunities/route.ts
+++ b/app/api/clubs/[slug]/opportunities/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
@@ -51,12 +51,14 @@ const DATA: Record<string, Opportunity[]> = {
 };
 
 export async function GET(
-  _req: Request,
-  { params }: { params: { slug: string } },
+  _req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
 ) {
-  const slug = (params?.slug || '').toLowerCase();
-  // mappa slug→clubId (semplice euristica)
-  const clubId = slug.includes('carlentini') ? 'carlentini' : slug.includes('siracusa') ? 'siracusa' : slug;
+  const { slug } = await context.params; // 👈 Next 15.5: params è Promise
+  const s = (slug || '').toLowerCase();
+
+  // mappa slug→clubId (heuristic)
+  const clubId = s.includes('carlentini') ? 'carlentini' : s.includes('siracusa') ? 'siracusa' : s;
   const items = DATA[clubId] ?? [];
   return NextResponse.json({ items });
 }

--- a/app/api/clubs/[slug]/opportunities/route.ts
+++ b/app/api/clubs/[slug]/opportunities/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+type Opportunity = {
+  id: string;
+  title: string;
+  clubId: string;
+  clubName: string;
+  city?: string;
+  sport?: string;
+  roleName?: string;
+  createdAt?: string;
+};
+
+const DATA: Record<string, Opportunity[]> = {
+  carlentini: [
+    {
+      id: 'opp-car-001',
+      title: 'Prima Squadra — Terzino Destro',
+      clubId: 'carlentini',
+      clubName: 'ASD Club Atlético Carlentini',
+      city: 'Carlentini',
+      sport: 'Calcio',
+      roleName: 'TD',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString(),
+    },
+    {
+      id: 'opp-car-002',
+      title: 'Under 19 — Centrocampista',
+      clubId: 'carlentini',
+      clubName: 'ASD Club Atlético Carlentini',
+      city: 'Carlentini',
+      sport: 'Calcio',
+      roleName: 'CC',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    },
+  ],
+  siracusa: [
+    {
+      id: 'opp-sir-001',
+      title: 'U17 — Portiere',
+      clubId: 'siracusa',
+      clubName: 'SSD Siracusa Academy',
+      city: 'Siracusa',
+      sport: 'Calcio',
+      roleName: 'POR',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+    },
+  ],
+};
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { slug: string } },
+) {
+  const slug = (params?.slug || '').toLowerCase();
+  // mappa slug→clubId (semplice euristica)
+  const clubId = slug.includes('carlentini') ? 'carlentini' : slug.includes('siracusa') ? 'siracusa' : slug;
+  const items = DATA[clubId] ?? [];
+  return NextResponse.json({ items });
+}

--- a/app/api/clubs/[slug]/route.ts
+++ b/app/api/clubs/[slug]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+type Club = {
+  id: string;       // usato come clubId nelle azioni
+  slug: string;     // usato nel path pubblico
+  name: string;
+  city?: string;
+  sport?: string;
+  avatarUrl?: string;
+  coverUrl?: string;
+  about?: string;
+  followers?: number;
+};
+
+const CLUBS: Record<string, Club> = {
+  'club-atletico-carlentini': {
+    id: 'carlentini',
+    slug: 'club-atletico-carlentini',
+    name: 'ASD Club Atlético Carlentini',
+    city: 'Carlentini (SR)',
+    sport: 'Calcio',
+    avatarUrl: '',
+    coverUrl: '',
+    about:
+      'Club dilettantistico focalizzato su crescita giovani e comunità locale. Stagione 2025/26.',
+    followers: 3120,
+  },
+  'siracusa-academy': {
+    id: 'siracusa',
+    slug: 'siracusa-academy',
+    name: 'SSD Siracusa Academy',
+    city: 'Siracusa',
+    sport: 'Calcio',
+    avatarUrl: '',
+    coverUrl: '',
+    about: 'Settore giovanile e prima squadra.',
+    followers: 1890,
+  },
+};
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { slug: string } },
+) {
+  const slug = (params?.slug || '').toLowerCase();
+  const club = CLUBS[slug];
+  if (!club) {
+    return NextResponse.json({ ok: false, error: 'Club non trovato' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true, club });
+}

--- a/app/api/clubs/[slug]/route.ts
+++ b/app/api/clubs/[slug]/route.ts
@@ -1,10 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
 type Club = {
-  id: string;       // usato come clubId nelle azioni
-  slug: string;     // usato nel path pubblico
+  id: string;
+  slug: string;
   name: string;
   city?: string;
   sport?: string;
@@ -41,11 +41,13 @@ const CLUBS: Record<string, Club> = {
 };
 
 export async function GET(
-  _req: Request,
-  { params }: { params: { slug: string } },
+  _req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
 ) {
-  const slug = (params?.slug || '').toLowerCase();
-  const club = CLUBS[slug];
+  const { slug } = await context.params; // 👈 Next 15.5: params è Promise
+  const key = (slug || '').toLowerCase();
+  const club = CLUBS[key];
+
   if (!club) {
     return NextResponse.json({ ok: false, error: 'Club non trovato' }, { status: 404 });
   }

--- a/app/api/clubs/me/route.ts
+++ b/app/api/clubs/me/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  // TODO: derivare dallo user (whoami) o dal DB. Per ora default:
+  const club = {
+    id: 'carlentini',
+    slug: 'club-atletico-carlentini',
+    name: 'ASD Club Atlético Carlentini',
+  };
+  return NextResponse.json({ ok: true, club });
+}

--- a/app/api/feed/posts/route.ts
+++ b/app/api/feed/posts/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
+
+const COOKIE_KEY = 'feed_posts_v1';
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 365; // 1 anno
+const POST_LIMIT = 50;
+const MIN_INTERVAL_MS = 5000; // anti-spam: 5s tra un post e l'altro per utente
+
+type Post = {
+  id: string;
+  text: string;
+  createdAt: string; // ISO
+};
+
+type CookieShape = {
+  posts: Post[];
+  lastAt?: number; // epoch ms per anti-spam
+};
+
+async function readCookie(): Promise<CookieShape> {
+  try {
+    const store = await cookies(); // in questo progetto è async
+    const raw = store.get(COOKIE_KEY)?.value ?? '';
+    if (!raw) return { posts: [], lastAt: undefined };
+    const parsed = JSON.parse(raw);
+    const posts = Array.isArray(parsed?.posts) ? parsed.posts : [];
+    const lastAt = typeof parsed?.lastAt === 'number' ? parsed.lastAt : undefined;
+    return { posts, lastAt };
+  } catch {
+    return { posts: [], lastAt: undefined };
+  }
+}
+
+async function writeCookie(data: CookieShape) {
+  const store = await cookies();
+  store.set(COOKIE_KEY, JSON.stringify(data), {
+    path: '/',
+    httpOnly: true, // solo server-side; la UI passa sempre dall'API
+    sameSite: 'lax',
+    maxAge: MAX_AGE_SECONDS,
+  });
+}
+
+export async function GET() {
+  const { posts } = await readCookie();
+  // ordina dal più recente
+  const sorted = [...posts].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+  return NextResponse.json({ items: sorted });
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const text = (body?.text ?? '').toString().trim();
+
+    if (!text) {
+      return NextResponse.json({ ok: false, error: 'Testo vuoto' }, { status: 400 });
+    }
+    if (text.length > 500) {
+      return NextResponse.json({ ok: false, error: 'Testo troppo lungo (max 500 caratteri)' }, { status: 400 });
+    }
+
+    const now = Date.now();
+    const { posts, lastAt } = await readCookie();
+
+    if (typeof lastAt === 'number' && now - lastAt < MIN_INTERVAL_MS) {
+      const waitMs = MIN_INTERVAL_MS - (now - lastAt);
+      return NextResponse.json(
+        { ok: false, error: 'Rallenta per favore', retryAfterMs: waitMs },
+        { status: 429 },
+      );
+    }
+
+    const post: Post = {
+      id: `p_${now}`,
+      text,
+      createdAt: new Date(now).toISOString(),
+    };
+
+    const nextPosts = [post, ...posts].slice(0, POST_LIMIT);
+    await writeCookie({ posts: nextPosts, lastAt: now });
+
+    return NextResponse.json({ ok: true, post });
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Errore inatteso' }, { status: 500 });
+  }
+}

--- a/app/api/follows/suggestions/route.ts
+++ b/app/api/follows/suggestions/route.ts
@@ -1,33 +1,77 @@
 import { NextResponse } from 'next/server';
 
-export const dynamic = 'force-dynamic'; // evita caching aggressivo in dev
+export const dynamic = 'force-dynamic';
 
 type Role = 'club' | 'athlete' | 'guest';
 
-const CLUBS: any[] = [
-  { id: 'carlentini', name: 'ASD Club Atlético Carlentini', handle: 'clubatleticocarlentini', city: 'Carlentini (SR)', sport: 'Calcio', followers: 3120, avatarUrl: '' },
-  { id: 'siracusa', name: 'SSD Siracusa Academy', handle: 'siracusaacademy', city: 'Siracusa', sport: 'Calcio', followers: 1890, avatarUrl: '' },
-  { id: 'catania', name: 'ASD Catania Sud', handle: 'cataniasud', city: 'Catania', sport: 'Calcio', followers: 2540, avatarUrl: '' },
-  { id: 'lentini', name: 'ASD Lentini Sport', handle: 'lentinisport', city: 'Lentini', sport: 'Calcio', followers: 970, avatarUrl: '' },
+type Suggestion = {
+  id: string;
+  name: string;
+  handle: string;
+  avatarUrl?: string;
+  city?: string;
+  sport?: string;
+  followers?: number;
+};
+
+/**
+ * Dataset di esempio più lungo per abilitare paginazione.
+ * In produzione sostituire con query DB/servizio suggerimenti.
+ */
+const CLUBS: Suggestion[] = [
+  { id: 'c1', name: 'ASD Club Atlético Carlentini', handle: 'clubatleticocarlentini', city: 'Carlentini (SR)', sport: 'Calcio', followers: 3120 },
+  { id: 'c2', name: 'SSD Siracusa Academy', handle: 'siracusaacademy', city: 'Siracusa', sport: 'Calcio', followers: 1890 },
+  { id: 'c3', name: 'ASD Catania Sud', handle: 'cataniasud', city: 'Catania', sport: 'Calcio', followers: 2540 },
+  { id: 'c4', name: 'ASD Lentini Sport', handle: 'lentinisport', city: 'Lentini', sport: 'Calcio', followers: 970 },
+  { id: 'c5', name: 'ASD Augusta Calcio', handle: 'augustacalcio', city: 'Augusta', sport: 'Calcio', followers: 720 },
+  { id: 'c6', name: 'ASD Priolo Soccer', handle: 'priolosoccer', city: 'Priolo', sport: 'Calcio', followers: 610 },
+  { id: 'c7', name: 'ASD Villasmundo', handle: 'villasmundoasd', city: 'Villasmundo', sport: 'Calcio', followers: 540 },
+  { id: 'c8', name: 'ASD Solarino', handle: 'solarinocalcio', city: 'Solarino', sport: 'Calcio', followers: 505 },
+  { id: 'c9', name: 'ASD Floridia', handle: 'floridiacalcio', city: 'Floridia', sport: 'Calcio', followers: 480 },
+  { id: 'c10', name: 'ASD Avola', handle: 'avolacalcio', city: 'Avola', sport: 'Calcio', followers: 450 },
+  { id: 'c11', name: 'ASD Pachino', handle: 'pachinocalcio', city: 'Pachino', sport: 'Calcio', followers: 420 },
+  { id: 'c12', name: 'ASD Noto', handle: 'notocalcio', city: 'Noto', sport: 'Calcio', followers: 390 },
 ];
 
-const ATHLETES: any[] = [
-  { id: 'a1', name: 'Marco Greco', handle: 'marco.greco9', city: 'Catania', sport: 'Calcio (ATT)', followers: 420, avatarUrl: '' },
-  { id: 'a2', name: 'Luca Foti', handle: 'lucafoti_7', city: 'Siracusa', sport: 'Calcio (CC)', followers: 380, avatarUrl: '' },
-  { id: 'a3', name: 'Davide Russo', handle: 'davide.russo', city: 'Augusta', sport: 'Calcio (POR)', followers: 210, avatarUrl: '' },
-  { id: 'a4', name: 'Salvo Pappalardo', handle: 'salvo.pappa', city: 'Carlentini', sport: 'Calcio (DC)', followers: 160, avatarUrl: '' },
+const ATHLETES: Suggestion[] = [
+  { id: 'a1', name: 'Marco Greco', handle: 'marco.greco9', city: 'Catania', sport: 'Calcio (ATT)', followers: 420 },
+  { id: 'a2', name: 'Luca Foti', handle: 'lucafoti_7', city: 'Siracusa', sport: 'Calcio (CC)', followers: 380 },
+  { id: 'a3', name: 'Davide Russo', handle: 'davide.russo', city: 'Augusta', sport: 'Calcio (POR)', followers: 210 },
+  { id: 'a4', name: 'Salvo Pappalardo', handle: 'salvo.pappa', city: 'Carlentini', sport: 'Calcio (DC)', followers: 160 },
+  { id: 'a5', name: 'Giorgio Di Mauro', handle: 'giorgiodm', city: 'Floridia', sport: 'Calcio (TS)', followers: 300 },
+  { id: 'a6', name: 'Andrea Rizzo', handle: 'andrearizzo', city: 'Avola', sport: 'Calcio (ALA)', followers: 280 },
+  { id: 'a7', name: 'Matteo Spina', handle: 'matt.spina', city: 'Siracusa', sport: 'Calcio (CC)', followers: 265 },
+  { id: 'a8', name: 'Simone Caruso', handle: 'simocaruso', city: 'Catania', sport: 'Calcio (ATT)', followers: 410 },
+  { id: 'a9', name: 'Riccardo Neri', handle: 'riccardo.neri', city: 'Priolo', sport: 'Calcio (TD)', followers: 150 },
+  { id: 'a10', name: 'Pietro Arena', handle: 'pietro.arena', city: 'Lentini', sport: 'Calcio (CC)', followers: 245 },
+  { id: 'a11', name: 'Alessio Grella', handle: 'agrella', city: 'Villasmundo', sport: 'Calcio (DC)', followers: 190 },
+  { id: 'a12', name: 'Tommaso Fazio', handle: 'tfazio', city: 'Noto', sport: 'Calcio (POR)', followers: 175 },
 ];
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const forRole = (url.searchParams.get('for') || 'guest') as Role;
 
-  // Heuristica semplice:
-  // - se l'utente è un atleta → suggerisci CLUBS
-  // - se l'utente è un club → suggerisci ATHLETES
-  // - guest → suggerisci CLUBS
-  const items =
-    forRole === 'club' ? ATHLETES.slice(0, 4) : CLUBS.slice(0, 4);
+  const limitRaw = url.searchParams.get('limit');
+  const limit = Math.min(Math.max(parseInt(limitRaw || '4', 10) || 4, 1), 8); // 1..8, default 4
 
-  return NextResponse.json({ items });
+  const cursorRaw = url.searchParams.get('cursor'); // offset 0-based
+  const offset = Math.max(parseInt(cursorRaw || '0', 10) || 0, 0);
+
+  // Heuristica:
+  // - atleta → suggerisci CLUBS
+  // - club → suggerisci ATHLETES
+  // - guest → CLUBS
+  const source = forRole === 'club' ? ATHLETES : CLUBS;
+
+  // Ordiniamo per followers desc per un minimo di coerenza
+  const sorted = [...source].sort((a, b) => (b.followers || 0) - (a.followers || 0));
+
+  const slice = sorted.slice(offset, offset + limit);
+  const nextCursor = offset + limit < sorted.length ? String(offset + limit) : null;
+
+  return NextResponse.json({
+    items: slice,
+    nextCursor, // string | null
+  });
 }

--- a/app/api/opportunities/apply/route.ts
+++ b/app/api/opportunities/apply/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
+
+const COOKIE_KEY = 'applied_opps';
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 365; // 1 anno
+
+async function readAppliedIds(): Promise<string[]> {
+  try {
+    const store = await cookies(); // Next 15 in questo progetto è async
+    const v = store.get(COOKIE_KEY)?.value ?? '[]';
+    const parsed = JSON.parse(v);
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeAppliedIds(ids: string[]): Promise<void> {
+  const store = await cookies();
+  store.set(COOKIE_KEY, JSON.stringify(ids), {
+    path: '/',
+    httpOnly: false, // leggibile client-side (stub)
+    sameSite: 'lax',
+    maxAge: MAX_AGE_SECONDS,
+  });
+}
+
+export async function GET() {
+  const ids = await readAppliedIds();
+  return NextResponse.json({ ids });
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const id = (body?.id ?? '').toString().trim();
+    const action = (body?.action ?? '').toString().trim(); // 'apply' | 'unapply' | ''
+
+    if (!id) {
+      return NextResponse.json({ ok: false, error: 'Missing id' }, { status: 400 });
+    }
+
+    const current = new Set(await readAppliedIds());
+    let applied: boolean;
+
+    if (action === 'apply') {
+      current.add(id);
+      applied = true;
+    } else if (action === 'unapply') {
+      current.delete(id);
+      applied = false;
+    } else {
+      // toggle
+      if (current.has(id)) {
+        current.delete(id);
+        applied = false;
+      } else {
+        current.add(id);
+        applied = true;
+      }
+    }
+
+    const updated = Array.from(current);
+    await writeAppliedIds(updated);
+    return NextResponse.json({ ok: true, applied, ids: updated });
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Unexpected error' }, { status: 500 });
+  }
+}

--- a/app/c/[slug]/page.tsx
+++ b/app/c/[slug]/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import ClubHeader from '@/components/club/ClubHeader';
+import ClubOpportunitiesList from '@/components/club/ClubOpportunitiesList';
+
+export default function ClubPublicPage({ params }: { params: { slug: string } }) {
+  const slug = params.slug;
+
+  return (
+    <main className="container mx-auto px-4 py-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        {/* Contenuto principale */}
+        <section className="lg:col-span-8 flex flex-col gap-6">
+          <ClubHeader slug={slug} />
+          <ClubOpportunitiesList slug={slug} />
+        </section>
+
+        {/* Sidebar destra (placeholder per info aggiuntive) */}
+        <aside className="hidden xl:col-span-4 xl:block">
+          <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+            <h3 className="mb-2 text-sm font-semibold text-neutral-700 dark:text-neutral-200">Informazioni</h3>
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">
+              Contatti, social, staff e altre sezioni verranno aggiunte in seguito.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/app/u/[handle]/page.tsx
+++ b/app/u/[handle]/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import AthleteHeader from '@/components/athlete/AthleteHeader';
+import AthletePosts from '@/components/athlete/AthletePosts';
+
+export default function AthletePublicPage({ params }: { params: { handle: string } }) {
+  const handle = params.handle;
+
+  return (
+    <main className="container mx-auto px-4 py-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <section className="lg:col-span-8 flex flex-col gap-6">
+          <AthleteHeader handle={handle} />
+          <AthletePosts handle={handle} />
+        </section>
+
+        <aside className="hidden xl:col-span-4 xl:block">
+          <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+            <h3 className="mb-2 text-sm font-semibold text-neutral-700 dark:text-neutral-200">Informazioni</h3>
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">
+              Scheda tecnica, statistiche e link verranno aggiunti nelle prossime iterazioni.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/components/athlete/AthleteHeader.tsx
+++ b/components/athlete/AthleteHeader.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type Athlete = {
+  id: string;
+  handle: string;
+  name: string;
+  age?: number;
+  position?: string;
+  city?: string;
+  sport?: string;
+  avatarUrl?: string;
+  coverUrl?: string;
+  about?: string;
+  followers?: number;
+};
+
+const UNDO_MS = 1200;
+
+export default function AthleteHeader({ handle }: { handle: string }) {
+  const [ath, setAth] = useState<Athlete | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [following, setFollowing] = useState(false);
+  const [pending, setPending] = useState(false);
+  const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setErr(null);
+        setLoading(true);
+
+        const r = await fetch(`/api/athletes/${encodeURIComponent(handle)}`, { cache: 'no-store' });
+        const dj = await r.json().catch(() => ({}));
+        if (!r.ok || !dj?.athlete) throw new Error(dj?.error || 'Errore caricamento atleta');
+        setAth(dj.athlete);
+
+        const gf = await fetch('/api/follows/toggle', { cache: 'no-store', credentials: 'include' });
+        const fj = await gf.json().catch(() => ({}));
+        const ids: string[] = Array.isArray(fj?.ids) ? fj.ids : [];
+        setFollowing(ids.includes(dj.athlete.id));
+      } catch (e: any) {
+        setErr(e?.message || 'Errore inatteso');
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      if (undoTimer.current) clearTimeout(undoTimer.current);
+    };
+  }, [handle]);
+
+  async function toggleFollow(withUndo = true) {
+    if (!ath) return;
+    setPending(true);
+    const prev = following;
+    const next = !following;
+    setFollowing(next);
+
+    try {
+      const res = await fetch('/api/follows/toggle', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: ath.id }),
+      });
+      if (!res.ok) throw new Error('toggle failed');
+
+      if (next && withUndo) {
+        if (undoTimer.current) clearTimeout(undoTimer.current);
+        undoTimer.current = setTimeout(() => {
+          undoTimer.current = null;
+        }, UNDO_MS);
+      } else if (!next && undoTimer.current) {
+        clearTimeout(undoTimer.current);
+        undoTimer.current = null;
+      }
+    } catch {
+      setFollowing(prev); // rollback
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <header className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="h-24 w-full animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+        <div className="mt-4 flex items-center gap-4">
+          <div className="h-16 w-16 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-1/2 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+      </header>
+    );
+  }
+
+  if (err || !ath) {
+    return (
+      <header className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="text-sm text-red-600">Errore: {err || 'Atleta non trovato'}</div>
+      </header>
+    );
+  }
+
+  const cover =
+    ath.coverUrl ||
+    'data:image/svg+xml;utf8,' +
+      encodeURIComponent(
+        `<svg xmlns="http://www.w3.org/2000/svg" width="800" height="160"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#0ea5e9"/></linearGradient></defs><rect width="800" height="160" fill="url(#g)"/></svg>`,
+      );
+
+  const avatar =
+    ath.avatarUrl ||
+    `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(ath.name)}`;
+
+  return (
+    <header className="overflow-hidden rounded-xl border bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="h-32 w-full bg-cover bg-center" style={{ backgroundImage: `url(${cover})` }} />
+      <div className="flex flex-wrap items-center gap-4 p-4">
+        <img
+          src={avatar}
+          alt={ath.name}
+          className="h-16 w-16 rounded-full ring-2 ring-white dark:ring-neutral-900"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-lg font-semibold">{ath.name}</div>
+          <div className="truncate text-xs text-neutral-500">
+            {ath.position ? ath.position : '—'}
+            {ath.age ? ` • ${ath.age} anni` : ''}
+            {ath.city ? ` • ${ath.city}` : ''}
+            {ath.sport ? ` • ${ath.sport}` : ''}
+            {typeof ath.followers === 'number' ? ` • ${ath.followers} follower` : ''}
+          </div>
+        </div>
+
+        {!following ? (
+          <button
+            type="button"
+            onClick={() => toggleFollow(true)}
+            disabled={pending}
+            aria-busy={pending}
+            className="rounded-xl border px-3 py-1.5 text-sm font-semibold hover:bg-neutral-50 disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            {pending ? '...' : 'Segui'}
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="rounded-xl border bg-neutral-900 px-3 py-1.5 text-sm font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900">
+              {pending ? '...' : 'Seguito ✓'}
+            </span>
+            {undoTimer.current && (
+              <button
+                type="button"
+                onClick={() => toggleFollow(false)}
+                className="text-xs underline text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+                title="Annulla"
+              >
+                Annulla
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {ath.about && (
+        <div className="border-t p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:text-neutral-300">
+          {ath.about}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/components/athlete/AthletePosts.tsx
+++ b/components/athlete/AthletePosts.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Post = { id: string; text: string; createdAt: string };
+
+export default function AthletePosts({ handle }: { handle: string }) {
+  const [items, setItems] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setErr(null);
+        setLoading(true);
+        const r = await fetch(`/api/athletes/${encodeURIComponent(handle)}/posts`, {
+          cache: 'no-store',
+          credentials: 'include',
+        });
+        const dj = await r.json().catch(() => ({}));
+        const list: Post[] = Array.isArray(dj?.items) ? dj.items : [];
+        setItems(list);
+      } catch (e: any) {
+        setErr(e?.message || 'Errore inatteso');
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [handle]);
+
+  return (
+    <section className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">📣 Aggiornamenti</div>
+
+      {loading ? (
+        <ul className="space-y-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <li key={i} className="rounded-lg border p-3 dark:border-neutral-800">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="mt-2 h-3 w-1/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            </li>
+          ))}
+        </ul>
+      ) : err ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-red-600 dark:border-neutral-800">
+          Errore: {err}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-neutral-500 dark:border-neutral-800">
+          Nessun post ancora.
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {items.map((p) => (
+            <li key={p.id} className="rounded-lg border p-3 dark:border-neutral-800">
+              <div className="whitespace-pre-wrap text-sm text-neutral-800 dark:text-neutral-100">{p.text}</div>
+              <div className="mt-2 text-xs text-neutral-500">
+                {new Date(p.createdAt).toLocaleString()}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/club/ClubHeader.tsx
+++ b/components/club/ClubHeader.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type Club = {
+  id: string;
+  slug: string;
+  name: string;
+  city?: string;
+  sport?: string;
+  avatarUrl?: string;
+  coverUrl?: string;
+  about?: string;
+  followers?: number;
+};
+
+const UNDO_MS = 1200;
+
+export default function ClubHeader({ slug }: { slug: string }) {
+  const [club, setClub] = useState<Club | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [following, setFollowing] = useState<boolean>(false);
+  const [pending, setPending] = useState(false);
+  const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setErr(null);
+        setLoading(true);
+
+        // club data
+        const r = await fetch(`/api/clubs/${encodeURIComponent(slug)}`, { cache: 'no-store' });
+        const dj = await r.json().catch(() => ({}));
+        if (!r.ok || !dj?.club) throw new Error(dj?.error || 'Errore caricamento club');
+        setClub(dj.club);
+
+        // follow state
+        const gf = await fetch('/api/follows/toggle', { cache: 'no-store', credentials: 'include' });
+        const fj = await gf.json().catch(() => ({}));
+        const ids: string[] = Array.isArray(fj?.ids) ? fj.ids : [];
+        setFollowing(ids.includes(dj.club.id));
+      } catch (e: any) {
+        setErr(e?.message || 'Errore inatteso');
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      if (undoTimer.current) clearTimeout(undoTimer.current);
+    };
+  }, [slug]);
+
+  async function toggleFollow(withUndo = true) {
+    if (!club) return;
+    setPending(true);
+    const prev = following;
+    const next = !following;
+    setFollowing(next);
+
+    try {
+      const res = await fetch('/api/follows/toggle', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: club.id }),
+      });
+      if (!res.ok) throw new Error('toggle failed');
+
+      if (next && withUndo) {
+        if (undoTimer.current) clearTimeout(undoTimer.current);
+        undoTimer.current = setTimeout(() => {
+          undoTimer.current = null;
+        }, UNDO_MS);
+      } else if (!next && undoTimer.current) {
+        clearTimeout(undoTimer.current);
+        undoTimer.current = null;
+      }
+    } catch {
+      setFollowing(prev); // rollback
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <header className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="h-24 w-full animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+        <div className="mt-4 flex items-center gap-4">
+          <div className="h-16 w-16 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-1/2 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+      </header>
+    );
+  }
+
+  if (err || !club) {
+    return (
+      <header className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="text-sm text-red-600">Errore: {err || 'Club non trovato'}</div>
+      </header>
+    );
+  }
+
+  const cover =
+    club.coverUrl ||
+    'data:image/svg+xml;utf8,' +
+      encodeURIComponent(
+        `<svg xmlns="http://www.w3.org/2000/svg" width="800" height="160"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#1d4ed8"/></linearGradient></defs><rect width="800" height="160" fill="url(#g)"/></svg>`,
+      );
+
+  const avatar =
+    club.avatarUrl ||
+    `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(club.name)}`;
+
+  return (
+    <header className="overflow-hidden rounded-xl border bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="h-32 w-full bg-cover bg-center" style={{ backgroundImage: `url(${cover})` }} />
+      <div className="flex flex-wrap items-center gap-4 p-4">
+        <img
+          src={avatar}
+          alt={club.name}
+          className="h-16 w-16 rounded-full ring-2 ring-white dark:ring-neutral-900"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-lg font-semibold">{club.name}</div>
+          <div className="truncate text-xs text-neutral-500">
+            {club.city ? club.city : '—'} {club.sport ? `• ${club.sport}` : ''}
+            {typeof club.followers === 'number' ? ` • ${club.followers} follower` : ''}
+          </div>
+        </div>
+        {!following ? (
+          <button
+            type="button"
+            onClick={() => toggleFollow(true)}
+            disabled={pending}
+            aria-busy={pending}
+            className="rounded-xl border px-3 py-1.5 text-sm font-semibold hover:bg-neutral-50 disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            {pending ? '...' : 'Segui'}
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="rounded-xl border bg-neutral-900 px-3 py-1.5 text-sm font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900">
+              {pending ? '...' : 'Seguito ✓'}
+            </span>
+            {undoTimer.current && (
+              <button
+                type="button"
+                onClick={() => toggleFollow(false)}
+                className="text-xs underline text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+                title="Annulla"
+              >
+                Annulla
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {club.about && (
+        <div className="border-t p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:text-neutral-300">
+          {club.about}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/components/club/ClubOpportunitiesList.tsx
+++ b/components/club/ClubOpportunitiesList.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import OpportunityActions from '@/components/opportunities/OpportunityActions';
+
+type Opp = {
+  id: string;
+  title: string;
+  clubId: string;
+  clubName: string;
+  city?: string;
+  sport?: string;
+  roleName?: string;
+  createdAt?: string;
+};
+
+export default function ClubOpportunitiesList({ slug }: { slug: string }) {
+  const [items, setItems] = useState<Opp[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setErr(null);
+        setLoading(true);
+        const r = await fetch(`/api/clubs/${encodeURIComponent(slug)}/opportunities`, {
+          cache: 'no-store',
+          credentials: 'include',
+        });
+        const dj = await r.json().catch(() => ({}));
+        const arr: Opp[] = Array.isArray(dj?.items) ? dj.items : [];
+        setItems(arr);
+      } catch (e: any) {
+        setErr(e?.message || 'Errore inatteso');
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [slug]);
+
+  return (
+    <section className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">📌 Opportunità del club</div>
+
+      {loading ? (
+        <ul className="space-y-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <li key={i} className="rounded-lg border p-3 dark:border-neutral-800">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="mt-2 h-3 w-1/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="mt-3 h-8 w-52 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            </li>
+          ))}
+        </ul>
+      ) : err ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-red-600 dark:border-neutral-800">
+          Errore: {err}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-neutral-500 dark:border-neutral-800">
+          Nessuna opportunità pubblicata da questo club.
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {items.map((it) => (
+            <li key={it.id} className="rounded-lg border p-3 dark:border-neutral-800">
+              <div className="mb-1 text-sm font-medium">{it.title}</div>
+              <div className="text-xs text-neutral-500">
+                {it.clubName}
+                {it.city ? ` · ${it.city}` : ''}
+                {it.roleName ? ` · ${it.roleName}` : ''}
+                {it.sport ? ` · ${it.sport}` : ''}
+                {it.createdAt ? ` · ${new Date(it.createdAt).toLocaleDateString()}` : ''}
+              </div>
+
+              <OpportunityActions
+                opportunityId={it.id}
+                clubId={it.clubId}
+                clubName={it.clubName}
+                compact
+                className="mt-3"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/feed/Composer.tsx
+++ b/components/feed/Composer.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const MAX_LEN = 500;
+
+export default function Composer() {
+  const [text, setText] = useState('');
+  const [posting, setPosting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    };
+  }, []);
+
+  async function onPublish() {
+    if (!text.trim()) return;
+    if (text.length > MAX_LEN) return;
+
+    setPosting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/feed/posts', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok || data?.ok === false) {
+        const msg =
+          data?.error ||
+          (res.status === 429 ? 'Stai andando troppo veloce, riprova tra poco.' : 'Errore durante la pubblicazione.');
+        setError(msg);
+        return;
+      }
+
+      // reset textarea
+      setText('');
+
+      // notifica locale
+      setToast('Pubblicato ✓');
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      toastTimer.current = setTimeout(() => setToast(null), 4000);
+
+      // evento globale per aggiornare la lista post
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('feed-post-created', { detail: data.post }));
+      }
+    } catch {
+      setError('Errore di rete. Riprova.');
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  const remaining = MAX_LEN - text.length;
+  const disabled = posting || !text.trim() || remaining < 0;
+
+  return (
+    <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-3 text-sm text-neutral-500">Condividi un aggiornamento</div>
+
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mb-3 rounded-lg border bg-green-50 px-3 py-2 text-sm text-green-700 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-300"
+        >
+          {toast}
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-3 rounded-lg border bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+        >
+          {error}
+        </div>
+      )}
+
+      <textarea
+        className="w-full rounded-xl border px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900"
+        rows={3}
+        placeholder="Scrivi qualcosa…"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        maxLength={MAX_LEN + 200} // permetti oltre per mostrare contatore negativo, ma blocchiamo col bottone
+      />
+
+      <div className="mt-2 flex items-center justify-between text-xs text-neutral-500">
+        <span>{remaining >= 0 ? `${remaining} caratteri rimanenti` : `-${Math.abs(remaining)} oltre il limite`}</span>
+        <button
+          onClick={onPublish}
+          disabled={disabled}
+          className="rounded-md border px-3 py-1.5 text-sm font-semibold hover:bg-neutral-50 disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          {posting ? 'Pubblico…' : 'Pubblica'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/feed/FeedPosts.tsx
+++ b/components/feed/FeedPosts.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Post = {
+  id: string;
+  text: string;
+  createdAt: string; // ISO
+};
+
+export default function FeedPosts() {
+  const [items, setItems] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unsub = () => {};
+
+    (async () => {
+      await load();
+      // ascolta post creati dal Composer
+      const onCreated = (e: any) => {
+        const post: Post | undefined = e?.detail;
+        if (post?.id) {
+          setItems((prev) => [post, ...prev]);
+        }
+      };
+      window.addEventListener('feed-post-created', onCreated as EventListener);
+      unsub = () => window.removeEventListener('feed-post-created', onCreated as EventListener);
+    })();
+
+    return () => unsub();
+  }, []);
+
+  async function load() {
+    try {
+      setErr(null);
+      setLoading(true);
+      const r = await fetch('/api/feed/posts', { credentials: 'include', cache: 'no-store' });
+      const data = await r.json().catch(() => ({}));
+      const list: Post[] = Array.isArray(data?.items) ? data.items : [];
+      setItems(list);
+    } catch (e: any) {
+      setErr(e?.message || 'Errore inatteso');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <section className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">📣 Post recenti</div>
+        <ul className="space-y-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <li key={i} className="rounded-lg border p-3 dark:border-neutral-800">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="mt-2 h-3 w-1/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            </li>
+          ))}
+        </ul>
+      </section>
+    );
+  }
+
+  if (err) {
+    return (
+      <section className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">📣 Post recenti</div>
+        <div className="rounded-lg border border-dashed p-4 text-sm text-red-600 dark:border-neutral-800">
+          Errore: {err}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">📣 Post recenti</div>
+      {items.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-neutral-500 dark:border-neutral-800">
+          Ancora nessun post. Scrivi il primo!
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {items.map((p) => (
+            <li key={p.id} className="rounded-lg border p-3 dark:border-neutral-800">
+              <div className="whitespace-pre-wrap text-sm text-neutral-800 dark:text-neutral-100">{p.text}</div>
+              <div className="mt-2 text-xs text-neutral-500">
+                {new Date(p.createdAt).toLocaleString()}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/feed/WhoToFollow.tsx
+++ b/components/feed/WhoToFollow.tsx
@@ -20,6 +20,8 @@ export default function WhoToFollow() {
   const [loading, setLoading] = useState(true);
   const [following, setFollowing] = useState<Set<string>>(new Set());
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -31,16 +33,12 @@ export default function WhoToFollow() {
         const nextRole: Role = raw === 'club' || raw === 'athlete' ? raw : 'guest';
         setRole(nextRole);
 
-        // 2) Suggerimenti
-        const qs = new URLSearchParams({ for: nextRole });
-        const s = await fetch(`/api/follows/suggestions?${qs.toString()}`, {
-          credentials: 'include',
-          cache: 'no-store',
-        });
-        const data = await s.json();
-        setItems(Array.isArray(data?.items) ? data.items : []);
+        // 2) Prima pagina suggerimenti
+        const { items: firstItems, nextCursor: nc } = await fetchSuggestions(nextRole);
+        setItems(firstItems);
+        setNextCursor(nc ?? null);
 
-        // 3) Stato "seguito"
+        // 3) Stato "seguito" (cookie-backed)
         const g = await fetch('/api/follows/toggle', { credentials: 'include', cache: 'no-store' });
         const gj = await g.json().catch(() => ({}));
         const ids: string[] = Array.isArray(gj?.ids) ? gj.ids : [];
@@ -48,20 +46,52 @@ export default function WhoToFollow() {
       } catch {
         setItems([]);
         setFollowing(new Set());
+        setNextCursor(null);
       } finally {
         setLoading(false);
       }
     })();
   }, []);
 
+  async function fetchSuggestions(forRole: Role, cursor?: string) {
+    const qs = new URLSearchParams({ for: forRole });
+    if (cursor) qs.set('cursor', cursor);
+    // opzionale: qs.set('limit', '4');
+    const res = await fetch(`/api/follows/suggestions?${qs.toString()}`, {
+      credentials: 'include',
+      cache: 'no-store',
+    });
+    if (!res.ok) return { items: [] as Suggestion[], nextCursor: null as string | null };
+    const data = await res.json().catch(() => ({}));
+    const items = Array.isArray(data?.items) ? (data.items as Suggestion[]) : [];
+    const nextCursor = typeof data?.nextCursor === 'string' ? data.nextCursor : null;
+    return { items, nextCursor };
+  }
+
+  async function loadMore() {
+    if (!nextCursor) return;
+    setLoadingMore(true);
+    try {
+      const { items: more, nextCursor: nc } = await fetchSuggestions(role, nextCursor);
+      // merge dedup per id
+      setItems((prev) => {
+        const byId = new Map(prev.map((x) => [x.id, x]));
+        for (const it of more) if (!byId.has(it.id)) byId.set(it.id, it);
+        return Array.from(byId.values());
+      });
+      setNextCursor(nc);
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
   async function toggleFollow(id: string) {
-    // optimistic UI
     setPendingId(id);
-    const isFollowing = following.has(id);
+    const wasFollowing = following.has(id);
     const prev = new Set(following);
     const next = new Set(following);
 
-    if (isFollowing) next.delete(id);
+    if (wasFollowing) next.delete(id);
     else next.add(id);
 
     setFollowing(next);
@@ -75,10 +105,9 @@ export default function WhoToFollow() {
       });
       if (!res.ok) throw new Error('toggle failed');
       const out = await res.json().catch(() => ({}));
-      if (Array.isArray(out?.ids)) setFollowing(new Set(out.ids)); // riallinea allo stato server
+      if (Array.isArray(out?.ids)) setFollowing(new Set(out.ids));
     } catch {
-      // rollback
-      setFollowing(prev);
+      setFollowing(prev); // rollback
     } finally {
       setPendingId(null);
     }
@@ -104,63 +133,99 @@ export default function WhoToFollow() {
     );
   }
 
-  if (!items.length) return null;
-
-  const title =
-    role === 'club'
-      ? 'Atleti suggeriti'
-      : role === 'athlete'
-      ? 'Club da seguire'
-      : 'Chi seguire';
+  // Filtriamo i già seguiti per l'empty state "hai già seguito tutti"
+  const visibleItems = items.filter((it) => !following.has(it.id));
 
   return (
     <aside className="rounded-2xl border bg-white/60 p-4 shadow-sm dark:bg-zinc-900/60">
-      <h3 className="mb-3 text-sm font-semibold text-zinc-700 dark:text-zinc-200">{title}</h3>
-      <ul className="space-y-3">
-        {items.map((it) => {
-          const isFollowing = following.has(it.id);
-          const isPending = pendingId === it.id;
+      <h3 className="mb-3 text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+        {role === 'club' ? 'Atleti suggeriti' : role === 'athlete' ? 'Club da seguire' : 'Chi seguire'}
+      </h3>
 
-          return (
-            <li key={it.id} className="flex items-center gap-3">
-              <img
-                src={
-                  it.avatarUrl ||
-                  `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(it.name)}`
-                }
-                alt={it.name}
-                className="h-10 w-10 rounded-full object-cover ring-1 ring-zinc-200 dark:ring-zinc-800"
-              />
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium">{it.name}</div>
-                <div className="truncate text-xs text-zinc-500">
-                  @{it.handle}
-                  {it.city ? ` · ${it.city}` : ''}
-                  {it.sport ? ` · ${it.sport}` : ''}
-                  {typeof it.followers === 'number' ? ` · ${it.followers} follower` : ''}
-                </div>
-              </div>
+      {visibleItems.length > 0 ? (
+        <>
+          <ul className="space-y-3">
+            {visibleItems.map((it) => {
+              const isPending = pendingId === it.id;
+              return (
+                <li key={it.id} className="flex items-center gap-3">
+                  <img
+                    src={
+                      it.avatarUrl ||
+                      `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(it.name)}`
+                    }
+                    alt={it.name}
+                    className="h-10 w-10 rounded-full object-cover ring-1 ring-zinc-200 dark:ring-zinc-800"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">{it.name}</div>
+                    <div className="truncate text-xs text-zinc-500">
+                      @{it.handle}
+                      {it.city ? ` · ${it.city}` : ''}
+                      {it.sport ? ` · ${it.sport}` : ''}
+                      {typeof it.followers === 'number' ? ` · ${it.followers} follower` : ''}
+                    </div>
+                  </div>
 
+                  <button
+                    type="button"
+                    onClick={() => toggleFollow(it.id)}
+                    disabled={isPending}
+                    aria-busy={isPending}
+                    className={[
+                      'rounded-xl border px-3 py-1.5 text-sm font-semibold transition',
+                      'hover:bg-zinc-50 dark:hover:bg-zinc-800',
+                      isPending ? 'opacity-70' : '',
+                    ].join(' ')}
+                  >
+                    {isPending ? '...' : 'Segui'}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          {nextCursor && (
+            <div className="mt-4">
               <button
                 type="button"
-                onClick={() => toggleFollow(it.id)}
-                disabled={isPending}
-                aria-pressed={isFollowing}
-                title={isFollowing ? 'Seguito' : 'Segui'}
-                className={[
-                  'rounded-xl border px-3 py-1.5 text-sm font-semibold transition',
-                  isFollowing
-                    ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
-                    : 'hover:bg-zinc-50 dark:hover:bg-zinc-800',
-                  isPending ? 'opacity-70' : '',
-                ].join(' ')}
+                onClick={loadMore}
+                disabled={loadingMore}
+                aria-busy={loadingMore}
+                className="w-full rounded-xl border px-3 py-2 text-sm font-semibold hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:hover:bg-zinc-800"
               >
-                {isPending ? '...' : isFollowing ? 'Seguito' : 'Segui'}
+                {loadingMore ? 'Carico…' : 'Mostra altri'}
               </button>
-            </li>
-          );
-        })}
-      </ul>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="rounded-lg border border-dashed p-4 text-center text-sm text-zinc-500 dark:border-zinc-800">
+          Hai già seguito tutti i profili suggeriti.
+          {nextCursor ? (
+            <div className="mt-3">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                aria-busy={loadingMore}
+                className="rounded-xl border px-3 py-1.5 text-sm font-semibold hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                {loadingMore ? 'Carico…' : 'Mostra altri suggerimenti'}
+              </button>
+            </div>
+          ) : (
+            <div className="mt-2">
+              <a
+                href="/search/club"
+                className="text-blue-600 hover:underline dark:text-blue-400"
+              >
+                Cerca altri profili
+              </a>
+            </div>
+          )}
+        </div>
+      )}
     </aside>
   );
 }

--- a/components/opportunities/OpportunitiesFilterBar.tsx
+++ b/components/opportunities/OpportunitiesFilterBar.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+
+export type OppFilters = {
+  role?: string; // es. 'POR', 'ATT', 'Centrocampista'
+  city?: string; // es. 'Catania'
+};
+
+export default function OpportunitiesFilterBar({
+  initial,
+  onApply,
+  className,
+}: {
+  initial?: OppFilters;
+  onApply: (f: OppFilters) => void;
+  className?: string;
+}) {
+  const [role, setRole] = useState(initial?.role ?? '');
+  const [city, setCity] = useState(initial?.city ?? '');
+
+  function apply() {
+    onApply({
+      role: role.trim() || undefined,
+      city: city.trim() || undefined,
+    });
+  }
+
+  function reset() {
+    setRole('');
+    setCity('');
+    onApply({});
+  }
+
+  return (
+    <div className={['rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900', className || ''].join(' ')}>
+      <div className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">🔎 Filtri</div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="sm:col-span-1">
+          <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-300">Ruolo/Posizione</label>
+          <input
+            className="w-full rounded-md border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+            placeholder="Es. Portiere, ATT, Centrocampista…"
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+          />
+        </div>
+        <div className="sm:col-span-1">
+          <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-300">Città</label>
+          <input
+            className="w-full rounded-md border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+            placeholder="Es. Catania, Siracusa…"
+            value={city}
+            onChange={(e) => setCity(e.target.value)}
+          />
+        </div>
+        <div className="sm:col-span-1 flex items-end gap-2">
+          <button
+            type="button"
+            onClick={apply}
+            className="rounded-md border px-3 py-2 text-sm font-semibold hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            Applica
+          </button>
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-md border px-3 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/opportunities/OpportunityActions.tsx
+++ b/components/opportunities/OpportunityActions.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type Role = 'club' | 'athlete' | 'guest';
+
+type Props = {
+  /** ID opportunità, usato per stato "candidatura" */
+  opportunityId: string;
+  /** ID del club proprietario (se presente abilita "Segui club") */
+  clubId?: string;
+  /** Nome del club (solo per aria-label / tooltips, opzionale) */
+  clubName?: string;
+  /** Se true usa pulsanti più compatti */
+  compact?: boolean;
+  /** Classe aggiuntiva wrapper */
+  className?: string;
+};
+
+const UNDO_WINDOW_APPLY_MS = 3000; // finestra undo per candidatura
+const UNDO_WINDOW_FOLLOW_MS = 1200; // come sugli utenti suggeriti
+
+export default function OpportunityActions({
+  opportunityId,
+  clubId,
+  clubName,
+  compact,
+  className,
+}: Props) {
+  const [role, setRole] = useState<Role>('guest');
+
+  // Stato candidatura
+  const [appliedSet, setAppliedSet] = useState<Set<string>>(new Set());
+  const [applyPendingId, setApplyPendingId] = useState<string | null>(null);
+  const applyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Stato follow club
+  const [followSet, setFollowSet] = useState<Set<string>>(new Set());
+  const [followPendingId, setFollowPendingId] = useState<string | null>(null);
+  const followTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        // Ruolo
+        const r = await fetch('/api/auth/whoami', { credentials: 'include', cache: 'no-store' });
+        const j = await r.json().catch(() => ({}));
+        const raw = (j?.role ?? '').toString().toLowerCase();
+        const nextRole: Role = raw === 'club' || raw === 'athlete' ? raw : 'guest';
+        setRole(nextRole);
+
+        // Applied
+        const ga = await fetch('/api/opportunities/apply', { credentials: 'include', cache: 'no-store' });
+        const aj = await ga.json().catch(() => ({}));
+        const aIds: string[] = Array.isArray(aj?.ids) ? aj.ids : [];
+        setAppliedSet(new Set(aIds));
+
+        // Follow (club)
+        if (clubId) {
+          const gf = await fetch('/api/follows/toggle', { credentials: 'include', cache: 'no-store' });
+          const fj = await gf.json().catch(() => ({}));
+          const fIds: string[] = Array.isArray(fj?.ids) ? fj.ids : [];
+          setFollowSet(new Set(fIds));
+        }
+      } catch {
+        setAppliedSet(new Set());
+        setFollowSet(new Set());
+      }
+    })();
+
+    return () => {
+      if (applyTimerRef.current) clearTimeout(applyTimerRef.current);
+      if (followTimerRef.current) clearTimeout(followTimerRef.current);
+    };
+  }, [clubId]);
+
+  const applied = appliedSet.has(opportunityId);
+  const following = !!clubId && followSet.has(clubId);
+
+  async function toggleApply(withUndoWindow = true) {
+    setApplyPendingId(opportunityId);
+    const prev = new Set(appliedSet);
+    const next = new Set(appliedSet);
+
+    if (applied) next.delete(opportunityId);
+    else next.add(opportunityId);
+
+    setAppliedSet(next);
+
+    try {
+      const res = await fetch('/api/opportunities/apply', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: opportunityId, action: applied ? 'unapply' : 'apply' }),
+      });
+      if (!res.ok) throw new Error('apply toggle failed');
+      const out = await res.json().catch(() => ({}));
+      if (Array.isArray(out?.ids)) setAppliedSet(new Set(out.ids));
+
+      // Programma undo window solo quando passi a "applied"
+      if (!applied && withUndoWindow) {
+        if (applyTimerRef.current) clearTimeout(applyTimerRef.current);
+        applyTimerRef.current = setTimeout(() => {
+          applyTimerRef.current = null; // chiude finestra undo
+        }, UNDO_WINDOW_APPLY_MS);
+      } else if (applied && applyTimerRef.current) {
+        clearTimeout(applyTimerRef.current);
+        applyTimerRef.current = null;
+      }
+    } catch {
+      setAppliedSet(prev); // rollback
+    } finally {
+      setApplyPendingId(null);
+    }
+  }
+
+  async function toggleFollow(withUndoWindow = true) {
+    if (!clubId) return;
+    setFollowPendingId(clubId);
+    const prev = new Set(followSet);
+    const next = new Set(followSet);
+
+    if (following) next.delete(clubId);
+    else next.add(clubId);
+
+    setFollowSet(next);
+
+    try {
+      const res = await fetch('/api/follows/toggle', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: clubId }),
+      });
+      if (!res.ok) throw new Error('follow toggle failed');
+      const out = await res.json().catch(() => ({}));
+      if (Array.isArray(out?.ids)) setFollowSet(new Set(out.ids));
+
+      // Finestra Undo breve quando passi a "Seguito"
+      if (!following && withUndoWindow) {
+        if (followTimerRef.current) clearTimeout(followTimerRef.current);
+        followTimerRef.current = setTimeout(() => {
+          followTimerRef.current = null;
+        }, UNDO_WINDOW_FOLLOW_MS);
+      } else if (following && followTimerRef.current) {
+        clearTimeout(followTimerRef.current);
+        followTimerRef.current = null;
+      }
+    } catch {
+      setFollowSet(prev);
+    } finally {
+      setFollowPendingId(null);
+    }
+  }
+
+  const btnBase =
+    'rounded-xl border text-sm font-semibold transition hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:hover:bg-zinc-800';
+  const btnPad = compact ? 'px-2.5 py-1' : 'px-3 py-1.5';
+
+  return (
+    <div className={['flex flex-wrap items-center gap-2', className || ''].join(' ')}>
+      {/* Candidati */}
+      {role === 'athlete' ? (
+        !applied ? (
+          <button
+            type="button"
+            onClick={() => toggleApply(true)}
+            disabled={applyPendingId === opportunityId}
+            aria-busy={applyPendingId === opportunityId}
+            className={[btnBase, btnPad].join(' ')}
+            title="Invia candidatura (stub)"
+          >
+            {applyPendingId === opportunityId ? '...' : 'Candidati'}
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span
+              className={[
+                'rounded-xl border',
+                btnPad,
+                'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900',
+              ].join(' ')}
+              aria-live="polite"
+            >
+              {applyPendingId === opportunityId ? '...' : 'Candidatura inviata ✓'}
+            </span>
+            {/* Undo visibile solo nella finestra temporale */}
+            {applyTimerRef.current && (
+              <button
+                type="button"
+                onClick={() => toggleApply(false)} // annulla subito
+                className="text-xs underline text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                title="Annulla candidatura"
+              >
+                Annulla
+              </button>
+            )}
+          </div>
+        )
+      ) : role === 'club' ? (
+        <button type="button" className={[btnBase, btnPad].join(' ')} disabled title="Solo atleti">
+          Candidati
+        </button>
+      ) : (
+        <a href="/onboarding" className={[btnBase, btnPad].join(' ')}>
+          Accedi per candidarti
+        </a>
+      )}
+
+      {/* Segui club */}
+      {clubId ? (
+        !following ? (
+          <button
+            type="button"
+            onClick={() => toggleFollow(true)}
+            disabled={followPendingId === clubId}
+            aria-busy={followPendingId === clubId}
+            className={[btnBase, btnPad].join(' ')}
+            title={clubName ? `Segui ${clubName}` : 'Segui club'}
+          >
+            {followPendingId === clubId ? '...' : 'Segui club'}
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span
+              className={[
+                'rounded-xl border',
+                btnPad,
+                'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900',
+              ].join(' ')}
+              aria-live="polite"
+            >
+              {followPendingId === clubId ? '...' : 'Seguito ✓'}
+            </span>
+            {followTimerRef.current && (
+              <button
+                type="button"
+                onClick={() => toggleFollow(false)} // annulla subito
+                className="text-xs underline text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                title="Annulla segui"
+              >
+                Annulla
+              </button>
+            )}
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,40 +1,96 @@
-// middleware.ts (root)
-import { NextResponse, type NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
-export const config = {
-  matcher: ['/login', '/signup', '/onboarding', '/club/:path*'],
-};
+/**
+ * Rotte pubbliche (sempre accessibili, nessun redirect per login).
+ * NB: /feed resta pubblico come da tua UX: home anche per guest.
+ */
+const PUBLIC_PATHS = new Set<string>([
+  '/',           // verrà subito rediretto a /feed
+  '/feed',
+  '/onboarding',
+  '/login',
+  '/signup',
+]);
+
+/**
+ * Prefissi/rotte che richiedono autenticazione.
+ * Aggiungi qui altre aree riservate se/quando servono.
+ */
+const PROTECTED_PREFIXES = [
+  '/profile',
+  '/club/profile',
+  '/opportunities/new',
+  '/club/applicants',
+];
+
+/** true se la pathname richiede auth */
+function requiresAuth(pathname: string) {
+  return PROTECTED_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(p),
+  );
+}
+
+/** true se la pathname è pubblica */
+function isPublicPath(pathname: string) {
+  return PUBLIC_PATHS.has(pathname);
+}
 
 export async function middleware(req: NextRequest) {
-  const url = new URL(req.url);
-  const pathname = url.pathname;
+  const { pathname } = req.nextUrl;
 
-  let role: 'club' | 'athlete' | 'guest' = 'guest';
-  let authenticated = false;
+  // 1) Root → /feed (sempre)
+  if (pathname === '/') {
+    const url = req.nextUrl.clone();
+    url.pathname = '/feed';
+    return NextResponse.redirect(url);
+  }
 
+  // 2) Se non è rotta che richiede auth → passa
+  if (!requiresAuth(pathname)) {
+    return NextResponse.next();
+  }
+
+  // 3) Per le rotte protette, verifica autenticazione
+  //    Usiamo /api/auth/whoami (escluso dal matcher) e inoltriamo i cookie
   try {
-    const r = await fetch(new URL('/api/auth/whoami', url.origin), {
+    const whoamiUrl = new URL('/api/auth/whoami', req.url);
+    const res = await fetch(whoamiUrl, {
       headers: { cookie: req.headers.get('cookie') || '' },
       cache: 'no-store',
     });
-    const j = await r.json().catch(() => ({}));
-    authenticated = !!j?.user?.id;
-    const raw = (j?.role ?? '').toString().toLowerCase();
-    if (raw === 'club' || raw === 'athlete') role = raw;
+
+    let authed = false;
+    if (res.ok) {
+      const data = await res.json().catch(() => ({}));
+      authed = Boolean(data?.id || data?.email);
+    }
+
+    if (!authed) {
+      // Evita loop: non ridirigere se già in una pagina pubblica
+      if (!isPublicPath(pathname)) {
+        const url = req.nextUrl.clone();
+        url.pathname = '/onboarding';
+        url.searchParams.set('next', pathname); // per redirect post-login
+        return NextResponse.redirect(url);
+      }
+    }
   } catch {
-    // guest
+    // In caso di errore improvviso nell'auth check, lascia passare:
+    // meglio degradare a pubblico che bloccare.
+    return NextResponse.next();
   }
 
-  // Già loggato su /login o /signup? Vai in bacheca
-  if (authenticated && (pathname === '/login' || pathname === '/signup')) {
-    return NextResponse.redirect(new URL('/feed', url));
-  }
-
-  // Rotte /club/* solo per club
-  if (pathname.startsWith('/club/') && role !== 'club') {
-    return NextResponse.redirect(new URL('/feed', url));
-  }
-
-  // (opzionale) /onboarding -> qui lasciamo passare sempre per ora.
   return NextResponse.next();
 }
+
+/**
+ * Matcher:
+ * - esclude /api (incluso /api/auth/whoami), asset statici e immagini
+ * - intercetta tutto il resto
+ */
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|assets|images).*)',
+  ],
+};


### PR DESCRIPTION
- **feat(follows): add cursor-based pagination to suggestions API + empty state and load-more in WhoToFollow**
- **feat(follows): LinkedIn-like UX (Follow → Seguito + Undo; delayed removal + auto-refill to target)**
- **feat(opportunities): add Apply with undo + Follow club with undo; integrate actions into FeedLatest**
- **feat(feed): enable Composer with POST /api/feed/posts (stub, anti-spam, toast) + FeedPosts list**
- **fix(middleware): refine guard with explicit protected routes, root→/feed, and safe whoami check (no loops)**
- **feat(club-profile): public /c/[slug] with header+follow+opportunities and private /club/profile with link to public page; add clubs API stubs**
- **fix(api): Next 15.5 route handlers use NextRequest and await context.params (Promise)**
- **feat(opportunities): list page with role/city filters, normalized data, and client-side pagination**
- **feat(athlete-profile): public /u/[handle] with follow+undo and posts; private /profile with link to public; add athletes API stubs**
