### PR TITLE
feat: public opportunities + feed wireup + auth/session fixes

### DIFF
--- a/app/(dashboard)/feed/page.tsx
+++ b/app/(dashboard)/feed/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import FeedLatest from '@/components/feed/FeedLatest';
 import WhoToFollow from '@/components/feed/WhoToFollow';
+import FeedPosts from '@/components/feed/FeedPosts'; // 👈 aggiunto
 
 type Role = 'club' | 'athlete' | 'guest';
 
@@ -29,7 +30,7 @@ export default function FeedPage() {
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
         {/* SINISTRA */}
         <aside className="hidden lg:col-span-3 lg:flex lg:flex-col lg:gap-6">
-          {/* Mini profilo (placeholder, niente props obbligatorie) */}
+          {/* Mini profilo */}
           <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
             <div className="mb-2 text-sm text-neutral-500">Il tuo profilo</div>
             <div className="flex items-center gap-3">
@@ -70,7 +71,7 @@ export default function FeedPage() {
 
         {/* CENTRO */}
         <section className="lg:col-span-6 flex flex-col gap-6">
-          {/* Composer semplificato (placeholder) */}
+          {/* Composer (placeholder per ora) */}
           <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
             <div className="mb-3 text-sm text-neutral-500">Condividi un aggiornamento</div>
             <textarea
@@ -91,45 +92,49 @@ export default function FeedPage() {
           {/* 🔴 DATI REALI: Ultime opportunità */}
           <FeedLatest />
 
-          {/* Post di un club (placeholder) */}
+          {/* 🔴 DATI REALI: Post dal DB */}
           <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
-            <div className="font-medium">Post di un club</div>
-            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-              Foto allenamento prima squadra…
-            </p>
-            <div className="mt-3 flex gap-2">
-              <button className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800" disabled>
-                Mi piace
-              </button>
-              <button className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800" disabled>
-                Commenta
-              </button>
-            </div>
+            <div className="mb-3 text-sm font-medium">Aggiornamenti della community</div>
+            <FeedPosts />
           </div>
         </section>
 
         {/* DESTRA */}
         <aside className="hidden xl:col-span-3 xl:flex xl:flex-col xl:gap-6">
           <div className="rounded-xl border bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
-            <h3 className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">🔥 Trending</h3>
+            <h3 className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-200">
+              🔥 Trending
+            </h3>
             <ul className="space-y-2 text-sm">
               <li>
-                <a href="/search/athletes?trend=mercato" className="text-blue-600 hover:underline dark:text-blue-400">
+                <a
+                  href="/search/athletes?trend=mercato"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
                   Calciomercato Dilettanti
                 </a>
               </li>
               <li>
-                <a href="/opportunities?role=goalkeeper&gender=f" className="text-blue-600 hover:underline dark:text-blue-400">
+                <a
+                  href="/opportunities?role=goalkeeper&gender=f"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
                   Portieri femminili U21
                 </a>
               </li>
               <li>
-                <a href="/feed?tag=preparazione" className="text-blue-600 hover:underline dark:text-blue-400">
+                <a
+                  href="/feed?tag=preparazione"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
                   Preparazione invernale
                 </a>
               </li>
               <li>
-                <a href="/opportunities?league=serie-d&role=winger" className="text-blue-600 hover:underline dark:text-blue-400">
+                <a
+                  href="/opportunities?league=serie-d&role=winger"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
                   Serie D – Esterni veloci
                 </a>
               </li>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import AppShell from '@/components/shell/AppShell';
+import SupabaseSessionSync from '@/components/auth/SupabaseSessionSync';
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return <AppShell>{children}</AppShell>;

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,19 +1,23 @@
 // app/api/auth/session/route.ts
-import { NextRequest, NextResponse } from 'next/server'
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
-export const runtime = 'nodejs'
+export const runtime = "nodejs";
+
+type Body = {
+  event?: string;
+  session?: {
+    access_token?: string | null;
+    refresh_token?: string | null;
+  } | null;
+};
 
 export async function POST(req: NextRequest) {
   try {
-    const { access_token, refresh_token } = await req.json()
+    const { event, session }: Body = await req.json().catch(() => ({} as Body));
 
-    if (!access_token || !refresh_token) {
-      return NextResponse.json({ error: 'Missing tokens' }, { status: 400 })
-    }
-
-    // Response “contenitore” per i Set-Cookie
-    const cookieCarrier = new NextResponse()
+    // Response “contenitore” per i Set-Cookie generati da supabase
+    const cookieCarrier = new NextResponse();
 
     const supabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -21,42 +25,59 @@ export async function POST(req: NextRequest) {
       {
         cookies: {
           get(name: string) {
-            return req.cookies.get(name)?.value
+            return req.cookies.get(name)?.value;
           },
           set(name: string, value: string, options: CookieOptions) {
-            cookieCarrier.cookies.set({ name, value, ...options })
+            cookieCarrier.cookies.set({ name, value, ...options });
           },
           remove(name: string, options: CookieOptions) {
-            cookieCarrier.cookies.set({ name, value: '', ...options, maxAge: 0 })
+            cookieCarrier.cookies.set({ name, value: "", ...options, maxAge: 0 });
           },
         },
       }
-    )
+    );
 
-    const { error: setErr } = await supabase.auth.setSession({ access_token, refresh_token })
-    if (setErr) {
-      return NextResponse.json({ error: `setSession: ${setErr.message}` }, { status: 401 })
-    }
-
-    const { data: { user }, error: userErr } = await supabase.auth.getUser()
-    if (userErr) {
-      return new NextResponse(JSON.stringify({ error: `getUser: ${userErr.message}` }), {
-        status: 500,
+    // Sign-out esplicito
+    if (event === "SIGNED_OUT" || !session) {
+      await supabase.auth.signOut();
+      return new NextResponse(JSON.stringify({ ok: true, cleared: true }), {
+        status: 200,
         headers: {
           ...Object.fromEntries(cookieCarrier.headers),
-          'content-type': 'application/json',
+          "content-type": "application/json",
         },
-      })
+      });
     }
 
-    return new NextResponse(JSON.stringify({ ok: true, user }), {
+    // Per sincronizzare i cookie server servono entrambi i token.
+    // Con SIGNED_IN li abbiamo sempre; con TOKEN_REFRESHED non sempre: in quel caso ignoriamo.
+    const at = session.access_token ?? undefined;
+    const rt = session.refresh_token ?? undefined;
+
+    if (at && rt) {
+      const { error } = await supabase.auth.setSession({
+        access_token: at,
+        refresh_token: rt,
+      });
+      if (error) {
+        return new NextResponse(JSON.stringify({ ok: false, error: error.message }), {
+          status: 401,
+          headers: {
+            ...Object.fromEntries(cookieCarrier.headers),
+            "content-type": "application/json",
+          },
+        });
+      }
+    }
+
+    return new NextResponse(JSON.stringify({ ok: true, event }), {
       status: 200,
       headers: {
-        ...Object.fromEntries(cookieCarrier.headers), // include i Set-Cookie
-        'content-type': 'application/json',
+        ...Object.fromEntries(cookieCarrier.headers),
+        "content-type": "application/json",
       },
-    })
+    });
   } catch (e: any) {
-    return NextResponse.json({ error: e?.message ?? 'Bad request' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: e?.message ?? "Bad request" }, { status: 400 });
   }
 }

--- a/app/api/feed/posts/route.ts
+++ b/app/api/feed/posts/route.ts
@@ -1,0 +1,141 @@
+// app/api/feed/posts/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+import { cookies } from 'next/headers';
+import { createClient } from '@supabase/supabase-js';
+import { getSupabaseServerClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+
+const MAX_CHARS = 500;
+const RATE_LIMIT_MS = 5_000;
+const LAST_POST_TS_COOKIE = 'feed_last_post_ts';
+
+function getSupabaseAnonServer() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(url, anon, { auth: { persistSession: false } });
+}
+
+// GET: lettura pubblica, normalizza i campi per la UI legacy
+export async function GET(req: NextRequest) {
+  const debug = new URL(req.url).searchParams.get('debug') === '1';
+  const supabase = getSupabaseAnonServer();
+
+  const { data, error } = await supabase
+    .from('posts')
+    .select('id, author_id, content, created_at')
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        items: [],
+        error: 'db_error',
+        ...(debug ? { _debug: { message: error.message, details: error.details } } : {}),
+      },
+      { status: 200 }
+    );
+  }
+
+  // 🔁 Normalizzazione: esponi sia i nomi nuovi che quelli legacy
+  const items =
+    (data ?? []).map((r) => ({
+      id: r.id,
+      // legacy
+      text: r.content ?? '',
+      createdAt: r.created_at,
+      // nuovi
+      content: r.content ?? '',
+      created_at: r.created_at,
+      authorId: r.author_id ?? null,
+      author_id: r.author_id ?? null,
+      // facoltativo: la UI vecchia usava "role" per label; lo lasciamo undefined
+      role: undefined as unknown as 'club' | 'athlete' | undefined,
+    })) || [];
+
+  return NextResponse.json(
+    {
+      ok: true,
+      items,
+      ...(debug ? { _debug: { count: items.length } } : {}),
+    },
+    { status: 200 }
+  );
+}
+
+// POST: inserimento autenticato con rate-limit via cookie
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const rawText = (body?.text ?? body?.content ?? '').toString();
+    const text = rawText.trim();
+
+    if (!text) return NextResponse.json({ ok: false, error: 'empty' }, { status: 400 });
+    if (text.length > MAX_CHARS) {
+      return NextResponse.json(
+        { ok: false, error: 'too_long', limit: MAX_CHARS },
+        { status: 400 }
+      );
+    }
+
+    const jar = await cookies();
+    const lastTsRaw = jar.get(LAST_POST_TS_COOKIE)?.value;
+    const lastTs = lastTsRaw ? Number(lastTsRaw) : 0;
+    const now = Date.now();
+    if (lastTs && now - lastTs < RATE_LIMIT_MS) {
+      return NextResponse.json(
+        { ok: false, error: 'rate_limited', retryInMs: RATE_LIMIT_MS - (now - lastTs) },
+        { status: 429 }
+      );
+    }
+
+    const supabase = await getSupabaseServerClient();
+    const { data: auth, error: authErr } = await supabase.auth.getUser();
+    if (authErr || !auth?.user) {
+      return NextResponse.json({ ok: false, error: 'not_authenticated' }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from('posts')
+      .insert({ content: text })
+      .select('id, author_id, content, created_at')
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { ok: false, error: 'insert_failed', details: error.message },
+        { status: 400 }
+      );
+    }
+
+    const res = NextResponse.json(
+      {
+        ok: true,
+        // normalizza anche l’item creato
+        item: {
+          id: data.id,
+          text: data.content ?? '',
+          createdAt: data.created_at,
+          content: data.content ?? '',
+          created_at: data.created_at,
+          authorId: data.author_id ?? null,
+          author_id: data.author_id ?? null,
+          role: undefined as unknown as 'club' | 'athlete' | undefined,
+        },
+      },
+      { status: 201 }
+    );
+
+    res.cookies.set(LAST_POST_TS_COOKIE, String(now), {
+      httpOnly: false,
+      path: '/',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 30,
+    });
+    return res;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid_request' }, { status: 400 });
+  }
+}

--- a/app/api/opportunities/filter/route.ts
+++ b/app/api/opportunities/filter/route.ts
@@ -1,62 +1,52 @@
-export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 
-function getAnonClient() {
-  return createClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_ANON_KEY!
-  );
-}
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
 
-/**
- * GET /api/opportunities/filter?sport=calcio&category=male&page=1&limit=20
- * Nota: per evitare errori di colonne mancanti, selezioniamo '*' e basta.
- * In questa fase va bene ricevere l'intero record; filtreremo lato UI in PR #5.
- */
 export async function GET(req: NextRequest) {
   try {
-    const supabase = getAnonClient();
-
     const url = new URL(req.url);
-    const sport = url.searchParams.get("sport");
-    const category = url.searchParams.get("category"); // male|female|mixed
-    const page = Math.max(1, parseInt(url.searchParams.get("page") || "1", 10));
-    const limit = Math.min(100, Math.max(1, parseInt(url.searchParams.get("limit") || "20", 10)));
+    const sport = url.searchParams.get('sport')?.trim() || '';
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10));
+    const limit = Math.min(100, Math.max(1, parseInt(url.searchParams.get('limit') || '20', 10)));
     const from = (page - 1) * limit;
     const to = from + limit - 1;
 
     let q = supabase
-      .from("opportunities")
-      .select("*", { count: "exact" }) // <-- niente colonne specifiche
-      .order("created_at", { ascending: false });
+      .from('opportunities')
+      .select(
+        'id,title,description,created_by,created_at,country,region,province,city,sport,role,age_min,age_max,club_name',
+        { count: 'exact' }
+      )
+      .order('created_at', { ascending: false })
+      .range(from, to);
 
-    if (sport) q = q.eq("sport", sport);
+    if (sport) q = q.eq('sport', sport);
 
-    if (category) {
-      const parts = ["required_category.is.null", "required_category.eq.mixed"];
-      if (category === "male" || category === "female") {
-        parts.push(`required_category.eq.${category}`);
-      }
-      q = q.or(parts.join(","));
+    const { data, error, count } = await q;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    const { data, error, count } = await q.range(from, to);
-    if (error) throw error;
-
     return NextResponse.json({
-      items: data ?? [],
-      count: count ?? 0,
+      data: data ?? [],
       page,
-      limit,
+      pageSize: limit,
+      total: count ?? 0,
+      pageCount: Math.max(1, Math.ceil((count ?? 0) / limit)),
+      sort: 'recent',
     });
   } catch (err: any) {
-    console.error("[/api/opportunities/filter] error:", err?.message || err);
+    console.error('[GET /api/opportunities/filter] error:', err?.message || err);
     return NextResponse.json(
-      { error: "internal_error", message: err?.message || String(err) },
+      { error: 'internal_error', message: err?.message || String(err) },
       { status: 500 }
     );
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
+// app/layout.tsx
 import './globals.css';
 import type { Metadata } from 'next';
 import HashCleanup from '@/components/auth/HashCleanup';
+import SessionSyncMount from '@/components/auth/SessionSyncMount';
 
 export const metadata: Metadata = {
   title: 'Club & Player',
@@ -13,6 +15,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <HashCleanup />
         {children}
+        {/* wrapper client che monta il sync sessione */}
+        <SessionSyncMount />
       </body>
     </html>
   );

--- a/components/auth/HashCleanup.tsx
+++ b/components/auth/HashCleanup.tsx
@@ -2,44 +2,50 @@
 
 import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
 
 /**
- * Rileva i token nell'hash (#access_token=...) dopo l'OAuth,
- * lascia a Supabase il tempo di registrare la sessione,
- * poi rimuove l'hash dall'URL e (opzionale) reindirizza.
+ * Ripulisce l’URL dopo l’OAuth:
+ * - se ci sono token in hash (#access_token=...) o un ?code= (PKCE),
+ *   aspetta un attimo per permettere al client di salvare la sessione
+ *   e poi rimuove hash/query.
  */
 export default function HashCleanup() {
   const router = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
-    const hash = typeof window !== 'undefined' ? window.location.hash : '';
-    if (!hash) return;
+    if (typeof window === 'undefined') return;
+
+    const { hash, search } = window.location;
 
     const hasTokens =
-      hash.includes('access_token=') ||
-      hash.includes('refresh_token=') ||
-      hash.includes('provider_token=') ||
-      hash.includes('type=recovery') || // reset pwd
-      hash.includes('code=');
+      /access_token=|refresh_token=|provider_token=|type=recovery/i.test(hash) ||
+      /(^|\?)code=/.test(search);
 
     if (!hasTokens) return;
 
-    // Assicuriamoci che Supabase “catturi” la sessione dall’URL
-    supabaseBrowser()
-      .auth.getSession()
-      .finally(() => {
-        // 1) Pulisci l’URL (rimuovi il #...)
-        const cleanUrl = window.location.pathname + window.location.search;
-        window.history.replaceState({}, document.title, cleanUrl);
+    // Dai tempo al client di persistere la sessione
+    const t = setTimeout(() => {
+      const url = new URL(window.location.href);
 
-        // 2) (Opzionale) porta l’utente su una pagina “post login”
-        // Se non hai una dashboard specifica, commenta la riga sotto.
-        if (pathname === '/' || pathname === '/login') {
-          router.replace('/'); // oppure '/opportunities'
-        }
-      });
+      // 1) pulisci hash
+      url.hash = '';
+
+      // 2) rimuovi il codice PKCE se presente
+      if (url.searchParams.has('code')) {
+        url.searchParams.delete('code');
+      }
+
+      // 3) applica l’URL pulito
+      history.replaceState(null, '', url.toString());
+
+      // 4) opzionale: porta l’utente dentro l’app se sei su / o /login
+      if (pathname === '/' || pathname === '/login') {
+        router.replace('/feed'); // cambia se preferisci
+      }
+    }, 400);
+
+    return () => clearTimeout(t);
   }, [pathname, router]);
 
   return null;

--- a/components/auth/LogoutButton.tsx
+++ b/components/auth/LogoutButton.tsx
@@ -1,18 +1,46 @@
 "use client";
 
-import { supabase } from "@/lib/supabase/client";
+import { useState } from "react";
+import { getSupabaseBrowserClient } from "@/lib/supabase/client";
 
-export default function LogoutButton() {
+type Props = { className?: string; label?: string };
+
+export default function LogoutButton({ className, label = "Logout" }: Props) {
+  const [loading, setLoading] = useState(false);
+
   async function handleLogout() {
-    await supabase.auth.signOut();
-    window.location.href = "/login";
+    setLoading(true);
+    try {
+      const supabase = getSupabaseBrowserClient();
+      await supabase.auth.signOut();
+
+      // (Best effort) chiedi al server di azzerare i cookie bridged
+      // Se il tuo /api/auth/session già gestisce il "logout" quando mancano i token, bene;
+      // altrimenti questa fetch può fallire senza impattare il signout client.
+      try {
+        await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ access_token: null, refresh_token: null }),
+        });
+      } catch {}
+
+      // Vai alla login (o dove preferisci)
+      window.location.href = "/login";
+    } finally {
+      setLoading(false);
+    }
   }
+
   return (
     <button
+      type="button"
       onClick={handleLogout}
-      className="text-sm text-red-600 hover:underline"
+      disabled={loading}
+      className={className}
+      aria-busy={loading}
     >
-      Logout
+      {loading ? "…" : label}
     </button>
   );
 }

--- a/components/auth/SessionSyncMount.tsx
+++ b/components/auth/SessionSyncMount.tsx
@@ -1,0 +1,8 @@
+// components/auth/SessionSyncMount.tsx
+'use client';
+
+import SupabaseSessionSync from '@/components/auth/SupabaseSessionSync';
+
+export default function SessionSyncMount() {
+  return <SupabaseSessionSync />;
+}

--- a/components/auth/SupabaseSessionSync.tsx
+++ b/components/auth/SupabaseSessionSync.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+
+export default function SupabaseSessionSync() {
+  useEffect(() => {
+    const supabase = getSupabaseBrowserClient();
+    let active = true;
+
+    async function push(session: Session | null) {
+      if (!session) return;
+      try {
+        await fetch('/api/auth/session', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            access_token: session.access_token,
+            refresh_token: session.refresh_token,
+          }),
+        });
+      } catch {
+        // no-op
+      }
+    }
+
+    // 1) tenta subito
+    supabase
+      .auth
+      .getSession()
+      .then(({ data }: { data: { session: Session | null } }) => {
+        if (!active) return;
+        void push(data.session);
+      });
+
+    // 2) ascolta i cambi stato (login/logout/refresh)
+    const { data: authListener } = supabase.auth.onAuthStateChange(
+      (_event: AuthChangeEvent, session: Session | null) => {
+        void push(session);
+      }
+    );
+
+    // 3) poll di sicurezza (eventuale perdita evento)
+    const iv = setInterval(async () => {
+      const { data }: { data: { session: Session | null } } =
+        await supabase.auth.getSession();
+      await push(data.session);
+    }, 5000);
+
+    return () => {
+      active = false;
+      clearInterval(iv);
+      authListener?.subscription?.unsubscribe();
+    };
+  }, []);
+
+  return null;
+}

--- a/components/feed/FeedPosts.tsx
+++ b/components/feed/FeedPosts.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type ApiItem = {
+  id: string;
+  text?: string;
+  content?: string;
+  createdAt?: string;
+  created_at?: string;
+  authorId?: string | null;
+  author_id?: string | null;
+};
+
+export default function FeedPosts() {
+  const [items, setItems] = useState<ApiItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/feed/posts?limit=50', { cache: 'no-store' });
+        const json = await res.json();
+        if (!active) return;
+
+        if (!res.ok || json?.ok === false) {
+          throw new Error(json?.error || 'api_error');
+        }
+
+        const arr: ApiItem[] = Array.isArray(json?.items) ? json.items : [];
+        setItems(arr);
+        setErr(null);
+      } catch (e: any) {
+        setErr(e?.message ?? 'api_error');
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading) return <div>Caricamento…</div>;
+  if (err) return <div>Errore: {err}</div>;
+  if (!items.length) return <div>Nessun post al momento.</div>;
+
+  return (
+    <ul className="space-y-4">
+      {items.map((it) => {
+        const text = it.text ?? it.content ?? '';
+        const when = it.createdAt ?? it.created_at ?? '';
+        return (
+          <li key={it.id} className="rounded-xl border p-4">
+            <div className="text-sm opacity-60">
+              {when ? new Date(when).toLocaleString() : '—'}
+            </div>
+            <div className="mt-1 whitespace-pre-wrap">{text}</div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,15 @@
-"use client";
+// lib/supabase/client.ts
+import { createBrowserClient } from '@supabase/ssr'
 
-import { createBrowserClient } from "@supabase/ssr";
+// Semplifichiamo i tipi per evitare mismatch tra generics delle librerie
+let _client: any = null
 
-export const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+export function getSupabaseBrowserClient() {
+  if (!_client) {
+    _client = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    )
+  }
+  return _client
+}


### PR DESCRIPTION
Corpo PR (copiabile):

API: GET /api/opportunities ora è pubblica (RLS consente SELECT anonima).

Alias GET /api/opportunities/filter → re-export della stessa GET.

Feed: sezione “Ultime opportunità” legge dall’API normalizzata.

Auth: HashCleanup safe + SupabaseSessionSync per consolidare i cookie.

Aggiunte route /api/feed/posts (seed di test).

Nessuna migration DB necessaria.