### PR TITLE
feat(gdpr): cookie banner + pagine legali (privacy/terms) e mount in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,10 @@
 // app/layout.tsx
 import './globals.css';
 import type { Metadata } from 'next';
+
 import HashCleanup from '@/components/auth/HashCleanup';
 import SessionSyncMount from '@/components/auth/SessionSyncMount';
+import CookieConsent from '@/components/misc/CookieConsent';
 
 export const metadata: Metadata = {
   title: 'Club & Player',
@@ -13,10 +15,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="it">
       <body>
+        {/* Pulisce hash OAuth e fa redirect sicuro */}
         <HashCleanup />
+
+        {/* Contenuto pagina */}
         {children}
-        {/* wrapper client che monta il sync sessione */}
+
+        {/* Sync sessione client->server (cookie) */}
         <SessionSyncMount />
+
+        {/* Banner GDPR (fissato in basso) */}
+        <CookieConsent />
       </body>
     </html>
   );

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,16 +1,28 @@
-export const metadata = { title: 'Privacy' };
+export const metadata = {
+  title: 'Privacy Policy • Club & Player',
+};
 
 export default function PrivacyPage() {
   return (
-    <main className="container mx-auto px-4 py-8 prose dark:prose-invert">
-      <h1>Informativa Privacy</h1>
-      <p>Questa è un’informativa di esempio. Inserisci qui il testo fornito dal tuo consulente.</p>
-      <ul>
-        <li>Titolare del trattamento</li>
-        <li>Finalità e base giuridica</li>
-        <li>Conservazione dati</li>
-        <li>Diritti degli interessati</li>
-      </ul>
+    <main className="container mx-auto max-w-3xl px-4 py-8">
+      <h1 className="mb-4 text-2xl font-semibold">Privacy Policy</h1>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        Questa informativa descrive come trattiamo i dati personali degli utenti del servizio Club & Player.
+        Utilizziamo cookie tecnici necessari al funzionamento e strumenti di analisi in forma aggregata/anonima.
+      </p>
+      <h2 className="mt-6 text-lg font-semibold">Titolare del trattamento</h2>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        (Inserisci qui i riferimenti del titolare e il contatto.)
+      </p>
+      <h2 className="mt-6 text-lg font-semibold">Diritti dell’interessato</h2>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        Puoi richiedere accesso, rettifica, cancellazione, limitazione e opposizione scrivendo al titolare.
+      </p>
+      <h2 className="mt-6 text-lg font-semibold">Cookie</h2>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        I cookie necessari sono sempre attivi. I cookie di misurazione vengono attivati solo previa accettazione.
+      </p>
+      <p className="mt-8 text-sm text-neutral-500">Ultimo aggiornamento: {new Date().toLocaleDateString()}</p>
     </main>
   );
 }

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,0 +1,16 @@
+export const metadata = { title: 'Privacy' };
+
+export default function PrivacyPage() {
+  return (
+    <main className="container mx-auto px-4 py-8 prose dark:prose-invert">
+      <h1>Informativa Privacy</h1>
+      <p>Questa è un’informativa di esempio. Inserisci qui il testo fornito dal tuo consulente.</p>
+      <ul>
+        <li>Titolare del trattamento</li>
+        <li>Finalità e base giuridica</li>
+        <li>Conservazione dati</li>
+        <li>Diritti degli interessati</li>
+      </ul>
+    </main>
+  );
+}

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,10 +1,27 @@
-export const metadata = { title: 'Termini di Servizio' };
+export const metadata = {
+  title: 'Termini e Condizioni • Club & Player',
+};
 
 export default function TermsPage() {
   return (
-    <main className="container mx-auto px-4 py-8 prose dark:prose-invert">
-      <h1>Termini di Servizio</h1>
-      <p>Termini e condizioni d’uso. Inserisci il testo completo quando pronto.</p>
+    <main className="container mx-auto max-w-3xl px-4 py-8">
+      <h1 className="mb-4 text-2xl font-semibold">Termini e Condizioni</h1>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        L’uso del servizio Club & Player è soggetto ai presenti Termini. Creando un account accetti integralmente le condizioni.
+      </p>
+      <h2 className="mt-6 text-lg font-semibold">Uso consentito</h2>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        Non è consentito l’uso illecito, lo spam o la violazione dei diritti di terzi.
+      </p>
+      <h2 className="mt-6 text-lg font-semibold">Contenuti pubblicati</h2>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        Sei responsabile dei contenuti immessi; potremmo rimuovere contenuti che violano le policy.
+      </p>
+      <h2 className="mt-6 text-lg font-semibold">Limitazione di responsabilità</h2>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        Il servizio è fornito “as-is” senza garanzie; nei limiti di legge la responsabilità è limitata.
+      </p>
+      <p className="mt-8 text-sm text-neutral-500">Ultimo aggiornamento: {new Date().toLocaleDateString()}</p>
     </main>
   );
 }

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,0 +1,10 @@
+export const metadata = { title: 'Termini di Servizio' };
+
+export default function TermsPage() {
+  return (
+    <main className="container mx-auto px-4 py-8 prose dark:prose-invert">
+      <h1>Termini di Servizio</h1>
+      <p>Termini e condizioni d’uso. Inserisci il testo completo quando pronto.</p>
+    </main>
+  );
+}

--- a/components/misc/CookieConsent.tsx
+++ b/components/misc/CookieConsent.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const KEY = 'cp.cookie-consent.v1';
+
+export default function CookieConsent() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    // Mostra solo in produzione; se vuoi sempre: rimuovi il check
+    if (process.env.NODE_ENV !== 'production') return;
+    const v = localStorage.getItem(KEY);
+    if (!v) setOpen(true);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50">
+      <div className="mx-auto mb-4 w-[min(92%,900px)] rounded-xl border border-neutral-200 bg-white p-4 shadow-lg
+                      dark:border-neutral-800 dark:bg-neutral-900">
+        <p className="text-sm text-neutral-700 dark:text-neutral-200">
+          Usiamo cookie tecnici e, previo consenso, cookie per statistiche anonime.
+          Leggi la <Link href="/legal/privacy" className="text-blue-600 dark:text-blue-400 underline">Privacy</Link> e i
+          <Link href="/legal/terms" className="text-blue-600 dark:text-blue-400 underline"> Termini</Link>.
+        </p>
+        <div className="mt-3 flex gap-2">
+          <button
+            onClick={() => { localStorage.setItem(KEY, 'accept'); setOpen(false); }}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            Accetto
+          </button>
+          <button
+            onClick={() => { localStorage.setItem(KEY, 'reject'); setOpen(false); }}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            Solo necessari
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/misc/CookieConsent.tsx
+++ b/components/misc/CookieConsent.tsx
@@ -1,40 +1,52 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
 
-const KEY = 'cp.cookie-consent.v1';
+const STORAGE_KEY = 'cp-consent-v1';
 
 export default function CookieConsent() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    // Mostra solo in produzione; se vuoi sempre: rimuovi il check
-    if (process.env.NODE_ENV !== 'production') return;
-    const v = localStorage.getItem(KEY);
-    if (!v) setOpen(true);
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (!saved) setOpen(true);
+    } catch {
+      // ignora
+    }
   }, []);
 
   if (!open) return null;
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-50">
-      <div className="mx-auto mb-4 w-[min(92%,900px)] rounded-xl border border-neutral-200 bg-white p-4 shadow-lg
-                      dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mx-auto mb-4 w-[min(900px,92%)] rounded-xl border bg-white p-4 shadow-lg dark:border-neutral-800 dark:bg-neutral-900">
         <p className="text-sm text-neutral-700 dark:text-neutral-200">
-          Usiamo cookie tecnici e, previo consenso, cookie per statistiche anonime.
-          Leggi la <Link href="/legal/privacy" className="text-blue-600 dark:text-blue-400 underline">Privacy</Link> e i
-          <Link href="/legal/terms" className="text-blue-600 dark:text-blue-400 underline"> Termini</Link>.
+          Usiamo cookie tecnici e di misurazione anonima per migliorare il servizio.
+          Proseguendo accetti la nostra{' '}
+          <a className="underline" href="/legal/privacy" target="_blank" rel="noopener noreferrer">
+            Privacy Policy
+          </a>{' '}
+          e i{' '}
+          <a className="underline" href="/legal/terms" target="_blank" rel="noopener noreferrer">
+            Termini
+          </a>.
         </p>
         <div className="mt-3 flex gap-2">
           <button
-            onClick={() => { localStorage.setItem(KEY, 'accept'); setOpen(false); }}
+            onClick={() => {
+              try { localStorage.setItem(STORAGE_KEY, JSON.stringify({ consent: 'all', ts: Date.now() })); } catch {}
+              setOpen(false);
+            }}
             className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
           >
-            Accetto
+            Accetta
           </button>
           <button
-            onClick={() => { localStorage.setItem(KEY, 'reject'); setOpen(false); }}
+            onClick={() => {
+              try { localStorage.setItem(STORAGE_KEY, JSON.stringify({ consent: 'necessary', ts: Date.now() })); } catch {}
+              setOpen(false);
+            }}
             className="rounded-md border px-3 py-1.5 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
           >
             Solo necessari


### PR DESCRIPTION
Questa PR introduce il banner di consenso cookie e le pagine legali minime, oltre al mount del banner nel layout principale.

Cosa include

CookieConsent (components/misc/CookieConsent.tsx)

Banner bottom-bar con pulsanti Accetta / Rifiuta.

Persistenza scelta in localStorage con chiave cp-consent-v1.

Niente script di tracking caricati per ora: il banner serve a preparare GDPR/consensi, gli analytics verranno abilitati in una PR successiva.

Mount nel layout (app/layout.tsx)

Inserito <CookieConsent /> dopo <SessionSyncMount />, prima della chiusura del body.

Pagine legali

app/legal/privacy/page.tsx – Informativa Privacy (testo placeholder chiaro e pulito).

app/legal/terms/page.tsx – Termini di Servizio (testo placeholder chiaro e pulito).