### PR TITLE
Add Child Safety legal page and footer/sitemap entries

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,6 +72,7 @@ const FOOTER_LINKS = [
   { href: '/legal/privacy', label: 'Privacy' },
   { href: '/legal/terms', label: 'Termini' },
   { href: '/legal/beta', label: 'Informativa Beta' },
+  { href: '/legal/child-safety', label: 'Child Safety' },
 ];
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/legal/child-safety/page.tsx
+++ b/app/legal/child-safety/page.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
   description: 'Standard di sicurezza dei minori applicati da Club & Player e contatti per segnalazioni.',
 };
 
-const SAFETY_EMAIL = 'clubandplayer@gmail.com';
+const SAFETY_EMAIL = 'support@clubandplayer.com';
 
 export default function ChildSafetyPage() {
   return (

--- a/app/legal/child-safety/page.tsx
+++ b/app/legal/child-safety/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Standard di sicurezza dei minori • Club & Player',
+  description: 'Standard di sicurezza dei minori applicati da Club & Player e contatti per segnalazioni.',
+};
+
+const SAFETY_EMAIL = 'clubandplayer@gmail.com';
+
+export default function ChildSafetyPage() {
+  return (
+    <main className="container mx-auto max-w-3xl px-4 py-8">
+      <h1 className="mb-4 text-3xl font-semibold">Standard di sicurezza dei minori</h1>
+
+      <section className="space-y-3 text-sm text-neutral-700 dark:text-neutral-200">
+        <p>Club &amp; Player è una piattaforma dedicata ad atleti e club sportivi.</p>
+        <p>La piattaforma non è destinata ai minori di 13 anni.</p>
+        <p>Adottiamo misure per prevenire abusi e contenuti inappropriati, tra cui:</p>
+        <ul className="list-disc space-y-2 pl-6">
+          <li>possibilità di segnalare utenti e contenuti</li>
+          <li>monitoraggio delle attività sospette</li>
+          <li>rimozione di contenuti che violano le policy</li>
+        </ul>
+        <p>Non è consentita la pubblicazione o condivisione di contenuti che coinvolgono minori in modo improprio o illegale.</p>
+      </section>
+
+      <section className="mt-10 rounded-md border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-900">
+        <p>
+          Per segnalazioni o richieste relative alla sicurezza:{' '}
+          <a className="underline" href={`mailto:${SAFETY_EMAIL}`}>
+            {SAFETY_EMAIL}
+          </a>
+        </p>
+      </section>
+
+      <p className="mt-10 text-xs uppercase tracking-wide text-neutral-500">
+        Ultimo aggiornamento: {new Date().toLocaleDateString('it-IT')}
+      </p>
+    </main>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -28,5 +28,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     // legal
     { url: `${site}/legal/privacy`, lastModified: now, changeFrequency: 'yearly', priority: 0.2 },
     { url: `${site}/legal/terms`,   lastModified: now, changeFrequency: 'yearly', priority: 0.2 },
+    { url: `${site}/legal/child-safety`, lastModified: now, changeFrequency: 'yearly', priority: 0.2 },
   ];
 }


### PR DESCRIPTION
### Motivation
- Provide a public page that satisfies Google Play "Child Safety" requirements and documents the app's safeguards for minors.
- Keep the new page consistent with the existing `/legal/*` pages in layout, styling and structure.
- Ensure the page is SEO-friendly and discoverable via the site footer and sitemap.

### Description
- Added a new public legal page at `app/legal/child-safety/page.tsx` with the requested Italian content and SEO metadata (`title` and `description`).
- The new page follows the same pattern and container classes used by other legal pages (`/legal/privacy`, `/legal/terms`, `/legal/beta`) and includes the contact email `clubandplayer@gmail.com` and a timestamp.
- Updated `app/layout.tsx` to add the `Child Safety` link to the footer links array so it appears alongside `Privacy`, `Termini` and `Informativa Beta`.
- Updated `app/sitemap.ts` to include the new URL `/legal/child-safety` for indexing.

### Testing
- Ran linting with `pnpm exec eslint app/legal/child-safety/page.tsx app/layout.tsx app/sitemap.ts` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce28ac4f8832b809e7b97b634e4c5)