### PR TITLE
Fix legal-page marketing header to match main brand style

### DIFF
--- a/components/layout/MarketingNavbar.tsx
+++ b/components/layout/MarketingNavbar.tsx
@@ -1,23 +1,16 @@
 import Link from 'next/link';
+import BrandLogo from '@/components/brand/BrandLogo';
 
 const NAV_LINKS = [
   { href: '/signup', label: 'Registrati' },
   { href: '/login', label: 'Accedi' },
-  { href: '/feed', label: 'Feed' },
-  { href: '/search-map?type=club', label: 'Club' },
-  { href: '/search-map?type=player', label: 'Atleti' },
 ];
 
 export default function MarketingNavbar() {
   return (
     <header className="fixed inset-x-0 top-0 z-40 border-b border-neutral-200 bg-white/80 backdrop-blur">
       <div className="mx-auto flex h-14 w-full max-w-5xl items-center justify-between px-4">
-        <Link
-          href="/signup"
-          className="text-base font-semibold tracking-tight text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        >
-          Club &amp; Player
-        </Link>
+        <BrandLogo variant="header" href="/feed" priority className="h-8 w-auto" />
 
         <nav aria-label="Navigazione principale" className="flex items-center gap-2 text-sm text-neutral-700">
           {NAV_LINKS.map((link) => (


### PR DESCRIPTION
### Motivation
- The unauthenticated legal pages used a different header with extra links and a plain-text wordmark, causing visual inconsistency with the rest of the site.
- The intent is to remove irrelevant nav items and ensure the legal header uses the shared brand asset so typography and colors match pages like `/feed`.

### Description
- Updated `components/layout/MarketingNavbar.tsx` to remove the `Feed`, `Club`, and `Atleti` links and leave only `Registrati` and `Accedi` in the marketing header.
- Replaced the plain text wordmark with the shared `BrandLogo` component (`variant="header"`) and added the import for it.
- Adjusted the logo usage to `BrandLogo variant="header" href="/feed" priority className="h-8 w-auto"` so the header logo matches site-wide styling.

### Testing
- Ran `npm run -s lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf6086bbc832bab9a6c82ecb4dba1)