### PR TITLE
feat(auth): collegamento sicuro provider Google/Apple sullo stesso profilo

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,6 +5,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 
+const SOCIAL_PROVIDERS = new Set(['google', 'apple']);
+
 async function getServerSupabase() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
@@ -90,6 +92,65 @@ export async function GET(req: NextRequest) {
     } catch (inner) {
       const msg = inner instanceof Error ? inner.message : 'Auth exchange failed';
       return redirectWithError(url, msg);
+    }
+  }
+
+  const intent = url.searchParams.get('intent') ?? 'signin';
+  const expectedProvider = (url.searchParams.get('provider') ?? '').toLowerCase();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    const appProvider = String((user as any)?.app_metadata?.provider ?? '').toLowerCase();
+    const provider = SOCIAL_PROVIDERS.has(expectedProvider) ? expectedProvider : appProvider;
+    const providerId = String((user as any)?.app_metadata?.provider_id ?? '').trim() || null;
+    const email = String(user.email ?? '').trim().toLowerCase() || null;
+    const emailVerified = Boolean((user as any)?.email_confirmed_at);
+
+    if (provider && SOCIAL_PROVIDERS.has(provider)) {
+      await supabase.from('user_auth_providers').upsert(
+        {
+          user_id: user.id,
+          provider,
+          provider_user_id: providerId,
+          email,
+          email_verified: emailVerified,
+          last_sign_in_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,provider' },
+      );
+    }
+
+    // Protezione anti-merge cieco: se arriva un NUOVO utente social ma esiste già
+    // un account storico con la stessa email verificata (Google/Apple), NON merge automatico.
+    if (intent === 'signin' && provider && email && emailVerified && SOCIAL_PROVIDERS.has(provider)) {
+      const { data: profileForUser } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (!profileForUser) {
+        const { data: candidates } = await supabase
+          .from('user_auth_providers')
+          .select('user_id, provider')
+          .eq('email', email)
+          .eq('email_verified', true)
+          .neq('user_id', user.id)
+          .in('provider', ['google', 'apple'])
+          .limit(2);
+
+        if ((candidates?.length ?? 0) === 1) {
+          await supabase.auth.signOut();
+          const conflict = new URL('/login', url.origin);
+          conflict.searchParams.set('link_required', '1');
+          conflict.searchParams.set('provider', provider);
+          conflict.searchParams.set('email', email);
+          return NextResponse.redirect(conflict, { status: 302 });
+        }
+      }
     }
   }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -32,6 +32,7 @@ export default function LoginPage() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [currentEmail, setCurrentEmail] = useState<string | null>(null);
+  const [linkRequiredMsg, setLinkRequiredMsg] = useState<string | null>(null);
   const emailId = 'login-email';
   const passwordId = 'login-password';
   const errorId = errorMsg ? 'login-error' : undefined;
@@ -52,6 +53,16 @@ export default function LoginPage() {
       } else {
         // se non valido, puliamo
         sessionStorage.removeItem('auth:redirect_to');
+      }
+
+      if (params.get('link_required') === '1') {
+        const provider = (params.get('provider') ?? 'social').toLowerCase();
+        const email = params.get('email') ?? '';
+        const providerLabel = provider === 'apple' ? 'Apple' : provider === 'google' ? 'Google' : 'social';
+        setLinkRequiredMsg(
+          `Abbiamo trovato un account già esistente${email ? ` per ${email}` : ''}. ` +
+            `Per sicurezza accedi prima con il metodo già usato, poi collega ${providerLabel} dal login autenticato.`,
+        );
       }
     } catch {
       // ignora
@@ -164,6 +175,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY`}
         {errorMsg && (
           <p id={errorId} className="rounded-md border border-red-300 bg-red-50 p-2 text-sm text-red-700" role="alert">
             {errorMsg}
+          </p>
+        )}
+
+        {linkRequiredMsg && (
+          <p className="rounded-md border border-amber-300 bg-amber-50 p-2 text-sm text-amber-800" role="status">
+            {linkRequiredMsg}
           </p>
         )}
 

--- a/components/auth/SocialLogin.tsx
+++ b/components/auth/SocialLogin.tsx
@@ -44,7 +44,23 @@ export default function SocialLogin({ label, provider = 'google' }: SocialLoginP
       // redirect SUL DOMINIO CORRENTE, sempre
       const origin =
         typeof window !== 'undefined' ? window.location.origin : '';
-      const redirectTo = `${origin}/auth/callback`;
+      const baseRedirect = `${origin}/auth/callback`;
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        const redirectTo = `${baseRedirect}?intent=link&provider=${provider}`;
+        const { error } = await (supabase.auth as any).linkIdentity({
+          provider,
+          options: { redirectTo },
+        });
+        if (error) throw error;
+        return;
+      }
+
+      const redirectTo = `${baseRedirect}?intent=signin&provider=${provider}`;
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider,

--- a/supabase/migrations/20261016100000_user_auth_providers.sql
+++ b/supabase/migrations/20261016100000_user_auth_providers.sql
@@ -1,0 +1,53 @@
+-- Track social providers linked to each auth user (safe account-linking support)
+create table if not exists public.user_auth_providers (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider text not null check (provider in ('google', 'apple')),
+  provider_user_id text,
+  email text,
+  email_verified boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_sign_in_at timestamptz,
+  constraint user_auth_providers_pkey primary key (user_id, provider)
+);
+
+create unique index if not exists user_auth_providers_provider_user_uidx
+  on public.user_auth_providers(provider, provider_user_id)
+  where provider_user_id is not null;
+
+create index if not exists user_auth_providers_email_idx
+  on public.user_auth_providers(lower(email))
+  where email is not null;
+
+alter table public.user_auth_providers enable row level security;
+
+drop policy if exists "user_auth_providers_select_self" on public.user_auth_providers;
+create policy "user_auth_providers_select_self"
+on public.user_auth_providers
+for select
+to authenticated
+using (user_id = auth.uid());
+
+drop policy if exists "user_auth_providers_write_self" on public.user_auth_providers;
+create policy "user_auth_providers_write_self"
+on public.user_auth_providers
+for all
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create or replace function public.set_user_auth_providers_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_user_auth_providers_updated_at on public.user_auth_providers;
+create trigger trg_user_auth_providers_updated_at
+before update on public.user_auth_providers
+for each row
+execute function public.set_user_auth_providers_updated_at();


### PR DESCRIPTION
### Motivation
- Evitare duplicati di account quando un utente accede con Google e/o Apple in giorni diversi e permettere il collegamento sicuro di più provider allo stesso profilo senza merge automatici rischiosi.
- Fornire una base minima e sicura (DB + guardrail backend + UX) per supportare linking esplicito di provider multipli mantenendo la compatibilità con i login esistenti.

### Description
- Aggiunto comportamento di linking esplicito: `components/auth/SocialLogin.tsx` ora usa `linkIdentity` quando l'utente è già autenticato e mantiene `signInWithOAuth` per i nuovi sign-in, propagando `intent` e `provider` al callback per distinguere i flussi.
- Estesa la callback OAuth `app/auth/callback/route.ts` per registrare/aggiornare il provider in `public.user_auth_providers` e introdurre un guardrail anti-merge: se un nuovo social sign-in trova esattamente un altro account storico con la stessa email verificata, non viene fatto merge automatico ma si esegue sign-out e redirect al login con `link_required=1` (richiesta di linking esplicito).
- Aggiunta UX minima in `app/login/page.tsx` per mostrare un messaggio informativo quando il callback segnala `link_required`, guidando l'utente a effettuare il login con il metodo già usato e quindi collegare il nuovo provider dal proprio account.
- Creata migrazione DB `supabase/migrations/20261016100000_user_auth_providers.sql` che crea la tabella `public.user_auth_providers` (PK `(user_id, provider)`), indice unico su `(provider, provider_user_id)`, indice su `lower(email)`, RLS e trigger `updated_at` per tracciare provider social collegati ad ogni `auth.users.id`.
- Principi rispettati: nessun merge automatico, nessuna modifica alla logica ruoli/onboarding, nessuna modifica al mobile o refactor esteso.

### Testing
- Eseguiti controlli statici: `pnpm lint` (ESLint) — PASS.
- Eseguito typecheck TypeScript: `pnpm typecheck` (`tsc --noEmit`) — PASS.
- Non sono stati eseguiti build o test end-to-end in questo cambiamento; la modifica è limitata al flusso OAuth e alla migrazione database da applicare separatamente in ambiente DB.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a0f6fa90832bb3aa7fe2a93ebcee)