### PR TITLE
Fix followed club card name responsiveness

### DIFF
--- a/app/(dashboard)/following/page.tsx
+++ b/app/(dashboard)/following/page.tsx
@@ -105,7 +105,7 @@ function FollowCard({ profile, type, showRosterToggle, inRoster, rosterPending, 
   const feedCSizePx = 40;
   const feedOffsetPx = 8;
   const cSizePx = Math.round(logoSizePx * (feedCSizePx / feedLogoSizePx) * 1.15);
-  const offsetPx = Math.round(logoSizePx * (feedOffsetPx / feedLogoSizePx) * 1.6);
+  const offsetPx = Math.max(1, Math.round(logoSizePx * (feedOffsetPx / feedLogoSizePx) * 0.6));
 
   const handleToggle = () => {
     if (!onToggleRoster || toggleDisabled) return;
@@ -135,9 +135,9 @@ function FollowCard({ profile, type, showRosterToggle, inRoster, rosterPending, 
               </span>
             ) : null}
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-1">
-              <p className="text-sm font-semibold text-neutral-900 dark:text-white truncate">{profile.name}</p>
+              <p className="break-words text-sm font-semibold leading-tight text-neutral-900 dark:text-white">{profile.name}</p>
             </div>
             {type === 'athlete' && (playerIso2 || playerCountryLabel) ? (
               <div className="mt-1 flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">


### PR DESCRIPTION
### Motivation
- Risolve il problema di overflow del nome del Club nella card "Following" causato dal badge di certificazione e da un contenitore testo non flessibile.

### Description
- Ridotto l'offset del badge certificazione e limitato con `Math.max(1, ...)` per evitare che il badge invada l'area del nome. 
- Reso il contenitore del testo responsivo aggiungendo `flex-1` a `min-w-0` e sostituito `truncate` con `break-words` e `leading-tight` per gestire nomi lunghi. 
- Modifiche applicate in `app/(dashboard)/following/page.tsx`.

### Testing
- Eseguito `pnpm exec eslint 'app/(dashboard)/following/page.tsx'` ed è passato senza errori.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf85f810832b952663c97fdc4365)