### PR TITLE
Exclude direct message kinds from notification bell and counts

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { jsonError, withAuth } from '@/lib/api/auth';
 import { successResponse } from '@/lib/api/standardResponses';
 import { getActiveProfile } from '@/lib/api/profile';
+import { buildBellExcludedKindsInClause } from '@/lib/notifications/bell';
 import type { NotificationWithActor } from '@/types/notifications';
 
 export const runtime = 'nodejs';
@@ -41,6 +42,7 @@ export const GET = withAuth(async (req, { supabase, user }) => {
       .from('notifications')
       .select('id, kind, payload, created_at, updated_at, read_at, read, actor_profile_id, recipient_profile_id')
       .eq('user_id', user.id)
+      .not('kind', 'in', buildBellExcludedKindsInClause())
       .order('created_at', { ascending: false });
 
     const paginated = all ? base.range((page - 1) * limit, page * limit - 1) : base.limit(limit);
@@ -119,7 +121,8 @@ export const GET = withAuth(async (req, { supabase, user }) => {
     const { count, error: countError } = await supabase
       .from('notifications')
       .select('id', { count: 'exact', head: true })
-      .eq('user_id', user.id);
+      .eq('user_id', user.id)
+      .not('kind', 'in', buildBellExcludedKindsInClause());
     if (countError) {
       return jsonError('Errore conteggio notifiche', 500, {
         endpointVersion: ENDPOINT_VERSION,

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -1,5 +1,6 @@
 import { withAuth } from '@/lib/api/auth';
 import { dbError, successResponse, unknownError } from '@/lib/api/standardResponses';
+import { buildBellExcludedKindsInClause } from '@/lib/notifications/bell';
 
 export const runtime = 'nodejs';
 
@@ -9,6 +10,7 @@ export const GET = withAuth(async (_req, { supabase, user }) => {
       .from('notifications')
       .select('id', { count: 'exact', head: true })
       .eq('user_id', user.id)
+      .not('kind', 'in', buildBellExcludedKindsInClause())
       .or('read_at.is.null,read.eq.false');
 
     if (error) return dbError(error.message);

--- a/lib/notifications/bell.ts
+++ b/lib/notifications/bell.ts
@@ -1,0 +1,5 @@
+export const BELL_EXCLUDED_KINDS = ['message', 'new_message'] as const;
+
+export function buildBellExcludedKindsInClause() {
+  return `(${BELL_EXCLUDED_KINDS.map((kind) => `"${kind}"`).join(',')})`;
+}


### PR DESCRIPTION
### Motivation
- Prevent direct messages from appearing in the bell UI and counts by excluding specific notification kinds (e.g. one-on-one messages).

### Description
- Added `lib/notifications/bell.ts` exporting `BELL_EXCLUDED_KINDS` and `buildBellExcludedKindsInClause()` which returns an SQL `IN`-clause string for the excluded kinds.
- Applied the exclusion to the notifications list query in `app/api/notifications/route.ts` by adding `.not('kind', 'in', buildBellExcludedKindsInClause())` and to the debug count query.
- Applied the same exclusion to the unread count endpoint in `app/api/notifications/unread-count/route.ts` to ensure the bell unread total omits those kinds.

### Testing
- Ran TypeScript typecheck with `tsc --noEmit` and existing backend unit tests via `npm test`, and they passed.
- Performed API smoke checks for `GET /api/notifications` and `GET /api/notifications/unread-count` to verify excluded kinds are not returned and counts reflect the exclusion, and they behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1d39fefc832ba70422cf3d5ea27d)