### PR TITLE
Add push token storage backend (migration + endpoints)

### DIFF
--- a/app/api/push-tokens/route.ts
+++ b/app/api/push-tokens/route.ts
@@ -10,37 +10,46 @@ type PushTokenPayload = {
   deviceId?: unknown;
 };
 
-function parsePostPayload(payload: PushTokenPayload) {
+type PostPayloadResult =
+  | { ok: false; response: Response }
+  | { ok: true; token: string; platform: 'ios' | 'android'; deviceId: string | null };
+
+type DeletePayloadResult =
+  | { ok: false; response: Response }
+  | { ok: true; token: string };
+
+function parsePostPayload(payload: PushTokenPayload): PostPayloadResult {
   const token = typeof payload.token === 'string' ? payload.token.trim() : '';
   const platform = typeof payload.platform === 'string' ? payload.platform.trim() : '';
   const deviceIdRaw = typeof payload.deviceId === 'string' ? payload.deviceId.trim() : '';
 
   if (!token) {
-    return { error: invalidPayload('token obbligatorio') };
+    return { ok: false, response: invalidPayload('token obbligatorio') };
   }
 
   if (platform !== 'ios' && platform !== 'android') {
-    return { error: invalidPayload('platform deve essere ios o android') };
+    return { ok: false, response: invalidPayload('platform deve essere ios o android') };
   }
 
   return {
+    ok: true,
     token,
     platform,
     deviceId: deviceIdRaw || null,
   };
 }
 
-function parseDeletePayload(payload: { token?: unknown }) {
+function parseDeletePayload(payload: { token?: unknown }): DeletePayloadResult {
   const token = typeof payload.token === 'string' ? payload.token.trim() : '';
   if (!token) {
-    return { error: invalidPayload('token obbligatorio') };
+    return { ok: false, response: invalidPayload('token obbligatorio') };
   }
-  return { token };
+  return { ok: true, token };
 }
 
 export const POST = withAuth(async (req: NextRequest, { supabase, user }) => {
   const parsed = parsePostPayload(await req.json().catch(() => ({})));
-  if ('error' in parsed) return parsed.error;
+  if (!parsed.ok) return parsed.response;
 
   try {
     const now = new Date().toISOString();
@@ -70,7 +79,7 @@ export const POST = withAuth(async (req: NextRequest, { supabase, user }) => {
 
 export const DELETE = withAuth(async (req: NextRequest, { supabase, user }) => {
   const parsed = parseDeletePayload(await req.json().catch(() => ({})));
-  if ('error' in parsed) return parsed.error;
+  if (!parsed.ok) return parsed.response;
 
   try {
     const now = new Date().toISOString();

--- a/app/api/push-tokens/route.ts
+++ b/app/api/push-tokens/route.ts
@@ -1,0 +1,92 @@
+import { type NextRequest } from 'next/server';
+import { withAuth } from '@/lib/api/auth';
+import { dbError, invalidPayload, successResponse, unknownError } from '@/lib/api/standardResponses';
+
+export const runtime = 'nodejs';
+
+type PushTokenPayload = {
+  token?: unknown;
+  platform?: unknown;
+  deviceId?: unknown;
+};
+
+function parsePostPayload(payload: PushTokenPayload) {
+  const token = typeof payload.token === 'string' ? payload.token.trim() : '';
+  const platform = typeof payload.platform === 'string' ? payload.platform.trim() : '';
+  const deviceIdRaw = typeof payload.deviceId === 'string' ? payload.deviceId.trim() : '';
+
+  if (!token) {
+    return { error: invalidPayload('token obbligatorio') };
+  }
+
+  if (platform !== 'ios' && platform !== 'android') {
+    return { error: invalidPayload('platform deve essere ios o android') };
+  }
+
+  return {
+    token,
+    platform,
+    deviceId: deviceIdRaw || null,
+  };
+}
+
+function parseDeletePayload(payload: { token?: unknown }) {
+  const token = typeof payload.token === 'string' ? payload.token.trim() : '';
+  if (!token) {
+    return { error: invalidPayload('token obbligatorio') };
+  }
+  return { token };
+}
+
+export const POST = withAuth(async (req: NextRequest, { supabase, user }) => {
+  const parsed = parsePostPayload(await req.json().catch(() => ({})));
+  if ('error' in parsed) return parsed.error;
+
+  try {
+    const now = new Date().toISOString();
+    const { error } = await supabase.from('push_tokens').upsert(
+      {
+        token: parsed.token,
+        user_id: user.id,
+        platform: parsed.platform,
+        device_id: parsed.deviceId,
+        enabled: true,
+        updated_at: now,
+        last_seen_at: now,
+      },
+      { onConflict: 'token' }
+    );
+
+    if (error) {
+      console.error('[api/push-tokens][POST] db error', error);
+      return dbError('Impossibile salvare il push token', error.message);
+    }
+
+    return successResponse({ saved: true });
+  } catch (error) {
+    return unknownError({ endpoint: '/api/push-tokens', error, message: 'Errore inatteso POST /api/push-tokens' });
+  }
+});
+
+export const DELETE = withAuth(async (req: NextRequest, { supabase, user }) => {
+  const parsed = parseDeletePayload(await req.json().catch(() => ({})));
+  if ('error' in parsed) return parsed.error;
+
+  try {
+    const now = new Date().toISOString();
+    const { error } = await supabase
+      .from('push_tokens')
+      .update({ enabled: false, updated_at: now, last_seen_at: now })
+      .eq('user_id', user.id)
+      .eq('token', parsed.token);
+
+    if (error) {
+      console.error('[api/push-tokens][DELETE] db error', error);
+      return dbError('Impossibile disattivare il push token', error.message);
+    }
+
+    return successResponse({ disabled: true });
+  } catch (error) {
+    return unknownError({ endpoint: '/api/push-tokens', error, message: 'Errore inatteso DELETE /api/push-tokens' });
+  }
+});

--- a/supabase/migrations/20260427120000_push_tokens.sql
+++ b/supabase/migrations/20260427120000_push_tokens.sql
@@ -1,0 +1,42 @@
+create table if not exists public.push_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  token text not null,
+  platform text not null check (platform in ('ios', 'android')),
+  device_id text,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  unique (token)
+);
+
+create index if not exists push_tokens_user_id_idx on public.push_tokens (user_id);
+create index if not exists push_tokens_enabled_idx on public.push_tokens (enabled);
+
+alter table public.push_tokens enable row level security;
+
+create policy "push_tokens_select_own"
+  on public.push_tokens
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "push_tokens_insert_own"
+  on public.push_tokens
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "push_tokens_update_own"
+  on public.push_tokens
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "push_tokens_delete_own"
+  on public.push_tokens
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation
- Fornire la base backend per salvare e disattivare i push token mobile senza implementare ancora l’invio di notifiche.
- Garantire che i token siano memorizzati in modo sicuro con RLS per limitare accesso/operazioni al proprietario.

### Description
- Aggiunta migration `supabase/migrations/20260427120000_push_tokens.sql` che crea `public.push_tokens` con i campi richiesti, `unique(token)`, indici su `user_id` e `enabled`, RLS abilitata e policy `SELECT/INSERT/UPDATE/DELETE` limitate a `auth.uid() = user_id`.
- Creata API autenticata `POST /api/push-tokens` che valida `token` e `platform`, esegue un `upsert` sicuro su `token`, forza `user_id` dalla sessione, imposta `enabled = true` e aggiorna `updated_at` e `last_seen_at` restituendo `successResponse`.
- Creata API autenticata `DELETE /api/push-tokens` che valida `token` e applica soft-disable impostando `enabled = false` (scoped su `user_id` + `token`) restituendo `successResponse`.
- Conferme: non è stato implementato l’invio push; non sono state modificate la bell/UI, le rotte `/api/notifications` o `/api/direct-messages`, i trigger SQL di notifiche, né il flusso auth/session; non sono stati installati nuovi pacchetti.
- Branch creata: `micro-pr-web-2-push-tokens`; file nuovi: `supabase/migrations/20260427120000_push_tokens.sql` e `app/api/push-tokens/route.ts`.

### Testing
- Eseguito `pnpm lint` e ha passato con successo (`✅`).
- Eseguito `pnpm run build` che ha fallito in questo ambiente (`⚠️`) a causa di errori di fetch su Google Fonts durante la build Next.js (errore di connessione esterna non correlato alla logica della micro-PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2570f07c832bb5408c510d430505)