### PR TITLE
Invio push Expo best-effort dopo insert notifiche DB

### DIFF
--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -3,6 +3,7 @@ import { withAuth, jsonError } from '@/lib/api/auth';
 import { rateLimit } from '@/lib/api/rateLimit';
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { getProfileByUserId } from '@/lib/api/profile';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 
 export const runtime = 'nodejs';
 
@@ -54,11 +55,34 @@ async function notifyApplicantStatus(params: {
       status,
     });
 
-    const { error } = await admin.from('notifications').insert(notificationPayload);
+    const { data: insertedNotification, error } = await admin
+      .from('notifications')
+      .insert(notificationPayload)
+      .select('id')
+      .maybeSingle();
     if (error) {
       console.warn('[applications/:id][notifyApplicantStatus] notifications insert failed', {
         message: error.message,
         notificationPayload,
+      });
+    } else if (insertedNotification?.id) {
+      const pushSummary = await sendPushForNotificationBestEffort({
+        supabase: admin,
+        userId: athleteId,
+        notificationId: String(insertedNotification.id),
+        kind: 'application_status',
+        payload: {
+          application_id: applicationId,
+          opportunity_id: opportunityId,
+          opportunity_title: opportunityTitle ?? null,
+          status,
+        },
+      });
+      console.info('[applications/:id][notifyApplicantStatus] push dispatch summary', {
+        athleteId,
+        applicationId,
+        notificationId: insertedNotification.id,
+        pushSummary,
       });
     }
   } catch (err) {

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -3,6 +3,7 @@ import { withAuth, jsonError } from '@/lib/api/auth';
 import { rateLimit } from '@/lib/api/rateLimit';
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { getProfileByUserId } from '@/lib/api/profile';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 
 export const runtime = 'nodejs';
 
@@ -64,11 +65,19 @@ async function notifyClubApplicationReceived(params: {
     opportunityId,
   });
 
-  let { error: nErr } = await admin.from('notifications').insert(notificationPayload);
+  let { data: insertedNotification, error: nErr } = await admin
+    .from('notifications')
+    .insert(notificationPayload)
+    .select('id')
+    .maybeSingle();
 
   if (nErr && missingReadColumn(nErr.message)) {
     const { read: _read, ...fallbackPayload } = notificationPayload;
-    ({ error: nErr } = await admin.from('notifications').insert(fallbackPayload));
+    ({ data: insertedNotification, error: nErr } = await admin
+      .from('notifications')
+      .insert(fallbackPayload)
+      .select('id')
+      .maybeSingle());
   }
 
   if (nErr) {
@@ -78,6 +87,25 @@ async function notifyClubApplicationReceived(params: {
       recipientUserId,
       applicationId,
       opportunityId,
+    });
+  } else if (insertedNotification?.id) {
+    const pushSummary = await sendPushForNotificationBestEffort({
+      supabase: admin,
+      userId: recipientUserId,
+      notificationId: String(insertedNotification.id),
+      kind: 'application_received',
+      payload: {
+        application_id: applicationId,
+        opportunity_id: opportunityId,
+        opportunity_title: opportunityTitle ?? null,
+        status: 'submitted',
+      },
+    });
+    console.info('[applications][notifyClubApplicationReceived] push dispatch summary', {
+      recipientUserId,
+      applicationId,
+      notificationId: insertedNotification.id,
+      pushSummary,
     });
   }
 }

--- a/app/api/feed/comments/route.ts
+++ b/app/api/feed/comments/route.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/validation/feed';
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { getProfileByUserId } from '@/lib/api/profile';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 
 export const runtime = 'nodejs';
 
@@ -237,7 +238,11 @@ export async function POST(req: NextRequest) {
         },
         read: false,
       };
-      const { error: notificationError } = await notificationsClient.from('notifications').insert(notificationPayload);
+      const { data: insertedNotification, error: notificationError } = await notificationsClient
+        .from('notifications')
+        .insert(notificationPayload)
+        .select('id')
+        .maybeSingle();
 
       if (notificationError) {
         console.warn('[api/feed/comments][POST] failed to insert notification', {
@@ -248,6 +253,25 @@ export async function POST(req: NextRequest) {
           actorProfileId,
           notificationPayload,
           message: notificationError.message,
+        });
+      } else if (insertedNotification?.id) {
+        const pushSummary = await sendPushForNotificationBestEffort({
+          supabase: notificationsClient,
+          userId: recipientUserId,
+          notificationId: String(insertedNotification.id),
+          kind: 'new_comment',
+          payload: {
+            post_id: postId,
+            comment_id: data.id,
+            body,
+          },
+        });
+        console.info('[api/feed/comments][POST] push dispatch summary', {
+          postId,
+          commentId: data.id,
+          notificationId: insertedNotification.id,
+          recipientUserId,
+          pushSummary,
         });
       }
     }

--- a/app/api/feed/reactions/route.ts
+++ b/app/api/feed/reactions/route.ts
@@ -10,6 +10,7 @@ import {
 import { getSupabaseServerClient } from '@/lib/supabase/server';
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { getProfileByUserId } from '@/lib/api/profile';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 import {
   CreateReactionSchema,
   ReactionCountsQuerySchema,
@@ -226,7 +227,11 @@ export async function POST(req: NextRequest) {
             },
             read: false,
           };
-          const { error: notificationError } = await notificationsClient.from('notifications').insert(notificationPayload);
+          const { data: insertedNotification, error: notificationError } = await notificationsClient
+            .from('notifications')
+            .insert(notificationPayload)
+            .select('id')
+            .maybeSingle();
 
           if (notificationError) {
             console.warn('[feed/reactions][POST] failed to insert notification', {
@@ -236,6 +241,23 @@ export async function POST(req: NextRequest) {
               actorProfileId,
               notificationPayload,
               message: notificationError.message,
+            });
+          } else if (insertedNotification?.id) {
+            const pushSummary = await sendPushForNotificationBestEffort({
+              supabase: notificationsClient,
+              userId: recipientUserId,
+              notificationId: String(insertedNotification.id),
+              kind: 'new_reaction',
+              payload: {
+                post_id: postId,
+                reaction: validReaction,
+              },
+            });
+            console.info('[feed/reactions][POST] push dispatch summary', {
+              postId,
+              recipientUserId,
+              notificationId: insertedNotification.id,
+              pushSummary,
             });
           }
         }

--- a/lib/push/sendExpoPush.ts
+++ b/lib/push/sendExpoPush.ts
@@ -1,0 +1,165 @@
+type PushSummary = {
+  attempted: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+};
+
+type SendPushParams = {
+  supabase: any;
+  userId: string;
+  notificationId: string;
+  kind: string;
+  payload?: Record<string, any> | null;
+};
+
+const EXCLUDED_KINDS = new Set(['message', 'new_message']);
+const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
+
+function createSummary(partial?: Partial<PushSummary>): PushSummary {
+  return {
+    attempted: partial?.attempted ?? 0,
+    sent: partial?.sent ?? 0,
+    skipped: partial?.skipped ?? 0,
+    failed: partial?.failed ?? 0,
+  };
+}
+
+function toExpoToken(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const token = value.trim();
+  if (!token) return null;
+  if (token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')) return token;
+  return null;
+}
+
+function buildTitle(kind: string) {
+  if (kind === 'new_comment') return 'Nuovo commento';
+  if (kind === 'new_reaction') return 'Nuova reazione';
+  if (kind === 'application_received') return 'Nuova candidatura';
+  if (kind === 'application_status') return 'Aggiornamento candidatura';
+  return 'Nuova notifica';
+}
+
+function buildBody(kind: string, payload?: Record<string, any> | null) {
+  const textFromPayload = [
+    payload?.comment_preview,
+    payload?.body,
+    payload?.opportunity_title,
+    payload?.status,
+    payload?.reaction,
+  ].find((value) => typeof value === 'string' && value.trim().length > 0);
+
+  if (typeof textFromPayload === 'string' && textFromPayload.trim()) {
+    return textFromPayload.trim().slice(0, 140);
+  }
+
+  if (kind === 'new_comment') return 'Hai ricevuto un nuovo commento.';
+  if (kind === 'new_reaction') return 'Hai ricevuto una nuova reazione.';
+  if (kind === 'application_received') return 'Hai ricevuto una nuova candidatura.';
+  if (kind === 'application_status') return 'Lo stato della candidatura è stato aggiornato.';
+  return 'Apri l’app per vedere i dettagli.';
+}
+
+export async function sendPushForNotificationBestEffort(params: SendPushParams): Promise<PushSummary> {
+  const { supabase, userId, notificationId, kind, payload } = params;
+
+  if (!supabase || !userId || !notificationId || !kind) {
+    return createSummary({ skipped: 1 });
+  }
+
+  if (EXCLUDED_KINDS.has(kind)) {
+    return createSummary({ skipped: 1 });
+  }
+
+  try {
+    const { data: tokenRows, error } = await supabase
+      .from('push_tokens')
+      .select('token')
+      .eq('user_id', userId)
+      .eq('enabled', true);
+
+    if (error) {
+      console.warn('[push/sendExpoPush] token lookup failed', {
+        userId,
+        notificationId,
+        kind,
+        message: error.message,
+      });
+      return createSummary({ failed: 1 });
+    }
+
+    const tokens = (tokenRows ?? [])
+      .map((row: any) => toExpoToken(row?.token))
+      .filter((token: string | null): token is string => !!token);
+
+    if (!tokens.length) {
+      return createSummary({ skipped: 1 });
+    }
+
+    const title = buildTitle(kind);
+    const body = buildBody(kind, payload);
+
+    let sent = 0;
+    let failed = 0;
+
+    await Promise.all(tokens.map(async (token: string) => {
+      try {
+        const response = await fetch(EXPO_PUSH_URL, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Accept-Encoding': 'gzip, deflate',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            to: token,
+            title,
+            body,
+            data: {
+              kind,
+              notificationId,
+              ...(payload ?? {}),
+            },
+          }),
+        });
+
+        if (!response.ok) {
+          failed += 1;
+          console.warn('[push/sendExpoPush] expo response not ok', {
+            userId,
+            notificationId,
+            kind,
+            status: response.status,
+          });
+          return;
+        }
+
+        sent += 1;
+      } catch (error: any) {
+        failed += 1;
+        console.warn('[push/sendExpoPush] expo send failed', {
+          userId,
+          notificationId,
+          kind,
+          token,
+          message: error?.message ?? 'unknown_error',
+        });
+      }
+    }));
+
+    return createSummary({
+      attempted: tokens.length,
+      sent,
+      failed,
+    });
+  } catch (error: any) {
+    console.warn('[push/sendExpoPush] unexpected error', {
+      userId,
+      notificationId,
+      kind,
+      message: error?.message ?? 'unknown_error',
+    });
+    return createSummary({ failed: 1 });
+  }
+}


### PR DESCRIPTION
### Motivation
- Aggiungere un invio push mobile best-effort subito dopo la creazione della notifica nel DB senza modificare il comportamento esistente della bell, i trigger SQL, /api/direct-messages o bloccare la creazione della notifica in caso di errori push.
- Fornire un helper isolato che legge token e invia via Expo HTTP API evitando dipendenze aggiuntive e retry loop.

### Description
- Aggiunto helper `sendPushForNotificationBestEffort` in `lib/push/sendExpoPush.ts` che legge token da `push_tokens` filtrando `enabled=true`, esclude `message/new_message`, costruisce payload minimo Expo e chiama `POST https://exp.host/--/api/v2/push/send`, gestisce errori con `try/catch`, non rilancia, logga server-side e ritorna summary `{ attempted, sent, skipped, failed }`.
- Agganciato l’invio push SOLO dopo insert notifica DB riuscita (si recupera `id` con `.select('id').maybeSingle()`) in questi producer: `app/api/feed/comments/route.ts` (kind `new_comment`), `app/api/feed/reactions/route.ts` (kind `new_reaction`), `app/api/applications/route.ts` (kind `application_received`) e `app/api/applications/[id]/route.ts` (kind `application_status`).
- Non sono state modificate le API `/api/notifications` né i trigger SQL, `/api/direct-messages` non è toccato, e non viene inviato push per `message/new_message` grazie a `EXCLUDED_KINDS`.
- La chiamata push è best-effort e non può bloccare la creazione della notifica DB perché viene eseguita dopo l'insert e l'helper non throwa verso il chiamante; vengono solo loggati i risultati.

### Testing
- Eseguiti `pnpm lint` e `pnpm exec tsc --noEmit`, entrambi passati con successo.
- Eseguito `pnpm run build` che ha fallito in questo ambiente CI per problemi di fetch di Google Fonts da `next/font` (errore di rete), non per errori TS o logica del codice; log di build disponibile nel run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef32f0cb68832b8bfae4ad31f9f606)