### PR TITLE
Add push token table + register/disable endpoints and support Bearer auth for server requests

### DIFF
--- a/app/api/push-tokens/disable/route.ts
+++ b/app/api/push-tokens/disable/route.ts
@@ -1,0 +1,64 @@
+import { withAuth } from '@/lib/api/auth';
+import { invalidPayload, successResponse, unknownError } from '@/lib/api/standardResponses';
+
+export const runtime = 'nodejs';
+
+type DisablePushTokenBody = {
+  token?: unknown;
+  device_id?: unknown;
+  disable_all?: unknown;
+};
+
+function normalizeToken(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const token = value.trim();
+  if (!token) return null;
+  return token;
+}
+
+function normalizeDeviceId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+export const POST = withAuth(async (req, { supabase, user }) => {
+  try {
+    const body = (await req.json().catch(() => ({}))) as DisablePushTokenBody;
+    const token = normalizeToken(body.token);
+    const deviceId = normalizeDeviceId(body.device_id);
+    const disableAll = body.disable_all === true;
+
+    if (!disableAll && !token && !deviceId) {
+      return invalidPayload('specifica token, device_id oppure disable_all=true');
+    }
+
+    let updateQuery = supabase
+      .from('push_tokens')
+      .update({ enabled: false, last_seen_at: new Date().toISOString() }, { count: 'exact' })
+      .eq('user_id', user.id);
+
+    if (!disableAll && token) {
+      updateQuery = updateQuery.eq('token', token);
+    }
+
+    if (!disableAll && deviceId) {
+      updateQuery = updateQuery.eq('device_id', deviceId);
+    }
+
+    const { error, count } = await updateQuery;
+
+    if (error) {
+      return unknownError({
+        endpoint: 'push-tokens/disable',
+        error,
+        message: error.message || 'Errore disabilitazione push token',
+      });
+    }
+
+    return successResponse({ updated: count || 0 });
+  } catch (error) {
+    return unknownError({ endpoint: 'push-tokens/disable', error });
+  }
+});

--- a/app/api/push-tokens/register/route.ts
+++ b/app/api/push-tokens/register/route.ts
@@ -1,0 +1,74 @@
+import { withAuth } from '@/lib/api/auth';
+import { invalidPayload, successResponse, unknownError } from '@/lib/api/standardResponses';
+
+export const runtime = 'nodejs';
+
+type RegisterPushTokenBody = {
+  token?: unknown;
+  platform?: unknown;
+  device_id?: unknown;
+};
+
+function normalizeToken(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const token = value.trim();
+  if (!token) return null;
+  if (token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')) return token;
+  return null;
+}
+
+function normalizePlatform(value: unknown): 'ios' | 'android' | null {
+  if (typeof value !== 'string') return null;
+  const platform = value.trim().toLowerCase();
+  if (platform === 'ios' || platform === 'android') return platform;
+  return null;
+}
+
+function normalizeDeviceId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 200);
+}
+
+export const POST = withAuth(async (req, { supabase, user }) => {
+  try {
+    const body = (await req.json().catch(() => ({}))) as RegisterPushTokenBody;
+    const token = normalizeToken(body.token);
+    if (!token) return invalidPayload('token push Expo non valido');
+
+    const platform = normalizePlatform(body.platform);
+    if (!platform) return invalidPayload('platform non valida (atteso ios|android)');
+
+    const now = new Date().toISOString();
+    const deviceId = normalizeDeviceId(body.device_id);
+
+    const { data, error } = await supabase
+      .from('push_tokens')
+      .upsert(
+        {
+          user_id: user.id,
+          token,
+          platform,
+          device_id: deviceId,
+          enabled: true,
+          last_seen_at: now,
+        },
+        { onConflict: 'token' }
+      )
+      .select('id, user_id, token, platform, device_id, enabled, created_at, updated_at, last_seen_at')
+      .single();
+
+    if (error) {
+      return unknownError({
+        endpoint: 'push-tokens/register',
+        error,
+        message: error.message || 'Errore registrazione push token',
+      });
+    }
+
+    return successResponse({ token: data });
+  } catch (error) {
+    return unknownError({ endpoint: 'push-tokens/register', error });
+  }
+});

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -24,19 +24,39 @@ export function jsonError(
   );
 }
 
+function resolveBearerToken(req: NextRequest): string | null {
+  const authorization = req.headers.get('authorization') ?? req.headers.get('Authorization');
+  if (!authorization) return null;
+  const [scheme, token] = authorization.split(' ');
+  if (!scheme || !token) return null;
+  if (scheme.toLowerCase() !== 'bearer') return null;
+  const trimmed = token.trim();
+  return trimmed ? trimmed : null;
+}
+
 /** Restituisce { ctx } se autenticato, altrimenti { res } con 401 */
-export async function requireAuth(_req: NextRequest): Promise<
+export async function requireAuth(req: NextRequest): Promise<
   | { ctx: AuthContext }
   | { res: NextResponse<{ error: string }> }
 > {
   const supabase = await getSupabaseServerClient();
-  const { data, error } = await supabase.auth.getUser();
-  const user = data?.user ?? null;
 
-  if (error || !user) {
-    return { res: jsonError('Unauthorized', 401) };
+  const byCookie = await supabase.auth.getUser();
+  const cookieUser = byCookie.data?.user ?? null;
+  if (!byCookie.error && cookieUser) {
+    return { ctx: { supabase, user: cookieUser } };
   }
-  return { ctx: { supabase, user } };
+
+  const bearerToken = resolveBearerToken(req);
+  if (bearerToken) {
+    const byBearer = await supabase.auth.getUser(bearerToken);
+    const bearerUser = byBearer.data?.user ?? null;
+    if (!byBearer.error && bearerUser) {
+      return { ctx: { supabase, user: bearerUser } };
+    }
+  }
+
+  return { res: jsonError('Unauthorized', 401) };
 }
 
 /** Wrapper comodo per i route handlers protetti */

--- a/supabase/migrations/20260427130000_add_push_tokens.sql
+++ b/supabase/migrations/20260427130000_add_push_tokens.sql
@@ -1,0 +1,92 @@
+-- Push tokens registry for Expo mobile notifications
+create table if not exists public.push_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  token text not null,
+  platform text not null check (platform in ('ios', 'android')),
+  device_id text,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  unique (token)
+);
+
+create index if not exists push_tokens_user_id_idx on public.push_tokens (user_id);
+create index if not exists push_tokens_enabled_idx on public.push_tokens (enabled);
+
+alter table public.push_tokens enable row level security;
+alter table public.push_tokens force row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'push_tokens'
+      and policyname = 'push_tokens_select_own'
+  ) then
+    create policy push_tokens_select_own
+      on public.push_tokens
+      for select
+      to authenticated
+      using (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'push_tokens'
+      and policyname = 'push_tokens_insert_own'
+  ) then
+    create policy push_tokens_insert_own
+      on public.push_tokens
+      for insert
+      to authenticated
+      with check (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'push_tokens'
+      and policyname = 'push_tokens_update_own'
+  ) then
+    create policy push_tokens_update_own
+      on public.push_tokens
+      for update
+      to authenticated
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'push_tokens'
+      and policyname = 'push_tokens_delete_own'
+  ) then
+    create policy push_tokens_delete_own
+      on public.push_tokens
+      for delete
+      to authenticated
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+create or replace function public.set_push_tokens_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_push_tokens_updated_at on public.push_tokens;
+create trigger trg_push_tokens_updated_at
+before update on public.push_tokens
+for each row
+execute function public.set_push_tokens_updated_at();


### PR DESCRIPTION
### Motivation
- Introduce server-side support for registering and disabling Expo push notification tokens so users can receive mobile notifications. 
- Persist tokens with per-user row-level security and automatic timestamps to manage active devices. 
- Allow API authentication using either Supabase session cookies or a Bearer token header to support mobile/third-party clients. 

### Description
- Added a new migration `supabase/migrations/20260427130000_add_push_tokens.sql` that creates the `push_tokens` table, indexes, RLS policies for per-user access, and a trigger to maintain `updated_at` timestamps. 
- Implemented a `POST /api/push-tokens/register` route in `app/api/push-tokens/register/route.ts` that validates `token`, `platform`, and optional `device_id` and `upsert`s the token with `enabled: true` and `last_seen_at`. 
- Implemented a `POST /api/push-tokens/disable` route in `app/api/push-tokens/disable/route.ts` that can disable tokens by `token`, `device_id`, or disable all tokens for the authenticated user. 
- Extended server auth helper in `lib/api/auth.ts` by adding `resolveBearerToken` and updating `requireAuth` to authenticate first via Supabase cookie and then via a provided Bearer token using `supabase.auth.getUser(token)`, while preserving the `withAuth` wrapper. 

### Testing
- No automated tests were run for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef62dd8004832b94cc5520cb28c982)