### PR TITLE
Support Bearer-token auth on server by adding client-with-token and using it in requireAuth

### DIFF
--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -2,7 +2,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import type { User } from '@supabase/supabase-js';
-import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { getSupabaseServerClient, getSupabaseServerClientWithAccessToken } from '@/lib/supabase/server';
 
 // Alias tipato sul client server-side che usi davvero
 type ServerSupabase = Awaited<ReturnType<typeof getSupabaseServerClient>>;
@@ -39,20 +39,21 @@ export async function requireAuth(req: NextRequest): Promise<
   | { ctx: AuthContext }
   | { res: NextResponse<{ error: string }> }
 > {
-  const supabase = await getSupabaseServerClient();
+  const cookieSupabase = await getSupabaseServerClient();
 
-  const byCookie = await supabase.auth.getUser();
+  const byCookie = await cookieSupabase.auth.getUser();
   const cookieUser = byCookie.data?.user ?? null;
   if (!byCookie.error && cookieUser) {
-    return { ctx: { supabase, user: cookieUser } };
+    return { ctx: { supabase: cookieSupabase, user: cookieUser } };
   }
 
   const bearerToken = resolveBearerToken(req);
   if (bearerToken) {
-    const byBearer = await supabase.auth.getUser(bearerToken);
+    const bearerSupabase = getSupabaseServerClientWithAccessToken(bearerToken);
+    const byBearer = await bearerSupabase.auth.getUser();
     const bearerUser = byBearer.data?.user ?? null;
     if (!byBearer.error && bearerUser) {
-      return { ctx: { supabase, user: bearerUser } };
+      return { ctx: { supabase: bearerSupabase as unknown as ServerSupabase, user: bearerUser } };
     }
   }
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 // lib/supabase/server.ts
 import { createServerClient } from '@supabase/ssr';
+import { createClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 
 /**
@@ -40,4 +41,21 @@ export async function getSupabaseServerClient() {
   });
 
   return supabase;
+}
+
+export function getSupabaseServerClientWithAccessToken(accessToken: string) {
+  const { url, anon } = resolveEnv();
+
+  return createClient(url, anon, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
 }


### PR DESCRIPTION
### Motivation
- Allow server route handlers to authenticate requests that provide a Bearer access token when no auth cookie is present.
- Ensure the Supabase client used for token-based auth does not persist sessions or auto-refresh tokens on the server.

### Description
- Added `getSupabaseServerClientWithAccessToken` to `lib/supabase/server.ts` which creates a `createClient` instance with the `Authorization` header and `auth` options to disable session persistence and token refresh. 
- Imported `createClient` and kept the existing `getSupabaseServerClient` that uses `createServerClient` with cookie adapters. 
- Updated `lib/api/auth.ts` to use a `cookieSupabase` for cookie-based user lookup and to build a `bearerSupabase` via the new helper for Bearer token lookup, returning the appropriate `supabase` instance in the auth context.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) and ESLint (`eslint`), and both completed without errors.
- No changes were made to existing unit tests and no new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef71dc6878832b8b89eec3872bb5b0)