### PR TITLE
Enable push notifications for messages and add Italian title/body

### DIFF
--- a/app/api/direct-messages/[profileId]/route.ts
+++ b/app/api/direct-messages/[profileId]/route.ts
@@ -29,6 +29,53 @@ function isMissingHiddenThreadsTable(error: any) {
     : error?.code === '42P01';
 }
 
+function cleanText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length ? normalized : null;
+}
+
+function toPushPreview(value: unknown) {
+  return cleanText(value)?.slice(0, 120) ?? '';
+}
+
+async function resolveSenderName(admin: any, senderProfileId: string) {
+  const { data: sender } = await admin
+    .from('profiles')
+    .select('id, display_name, full_name, account_type')
+    .eq('id', senderProfileId)
+    .maybeSingle();
+
+  if (!sender?.id) return 'un utente';
+
+  const senderAccountType = String(sender.account_type ?? '').toLowerCase();
+  if (senderAccountType === 'club') {
+    const { data: club } = await admin
+      .from('clubs_view')
+      .select('display_name')
+      .eq('id', senderProfileId)
+      .maybeSingle();
+    return cleanText(club?.display_name) || cleanText(sender.display_name) || cleanText(sender.full_name) || 'un utente';
+  }
+
+  if (senderAccountType === 'athlete') {
+    const { data: athlete } = await admin
+      .from('athletes_view')
+      .select('display_name, full_name')
+      .eq('id', senderProfileId)
+      .maybeSingle();
+    return (
+      cleanText(athlete?.display_name) ||
+      cleanText(athlete?.full_name) ||
+      cleanText(sender.display_name) ||
+      cleanText(sender.full_name) ||
+      'un utente'
+    );
+  }
+
+  return cleanText(sender.display_name) || cleanText(sender.full_name) || 'un utente';
+}
+
 async function notifyDirectMessage(params: {
   recipientProfileId: string;
   senderProfileId: string;
@@ -47,6 +94,8 @@ async function notifyDirectMessage(params: {
 
   if (!recipient?.user_id) return;
   const recipientUserId = String(recipient.user_id);
+  const normalizedPreview = toPushPreview(preview);
+  const senderName = await resolveSenderName(admin, senderProfileId);
 
   const { data: insertedNotification } = await admin
     .from('notifications')
@@ -60,7 +109,7 @@ async function notifyDirectMessage(params: {
         thread_id: senderProfileId,
         recipient_profile_id: recipientProfileId,
         message_id: messageId,
-        preview,
+        preview: normalizedPreview,
       },
       read: false,
     })
@@ -76,7 +125,10 @@ async function notifyDirectMessage(params: {
       payload: {
         message_id: messageId,
         thread_id: senderProfileId,
-        preview,
+        sender_profile_id: senderProfileId,
+        recipient_profile_id: recipientProfileId,
+        sender_name: senderName,
+        preview: normalizedPreview,
       },
     });
   }
@@ -226,7 +278,7 @@ export const POST = withAuth(async (req: NextRequest, { supabase, user }, routeC
         recipientProfileId: peer.id,
         senderProfileId: me.id,
         messageId: inserted.id as string,
-        preview: content.slice(0, 140),
+        preview: content,
       });
     }
 

--- a/app/api/direct-messages/[profileId]/route.ts
+++ b/app/api/direct-messages/[profileId]/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/api/standardResponses';
 import { withAuth } from '@/lib/api/auth';
 import { getActiveProfile, getProfileById } from '@/lib/api/profile';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 
 export const runtime = 'nodejs';
@@ -45,21 +46,40 @@ async function notifyDirectMessage(params: {
     .maybeSingle();
 
   if (!recipient?.user_id) return;
+  const recipientUserId = String(recipient.user_id);
 
-  await admin.from('notifications').insert({
-    user_id: recipient.user_id,
-    recipient_profile_id: recipientProfileId,
-    actor_profile_id: senderProfileId,
-    kind: 'message',
-    payload: {
-      sender_profile_id: senderProfileId,
-      thread_id: senderProfileId,
+  const { data: insertedNotification } = await admin
+    .from('notifications')
+    .insert({
+      user_id: recipientUserId,
       recipient_profile_id: recipientProfileId,
-      message_id: messageId,
-      preview,
-    },
-    read: false,
-  });
+      actor_profile_id: senderProfileId,
+      kind: 'message',
+      payload: {
+        sender_profile_id: senderProfileId,
+        thread_id: senderProfileId,
+        recipient_profile_id: recipientProfileId,
+        message_id: messageId,
+        preview,
+      },
+      read: false,
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (insertedNotification?.id) {
+    await sendPushForNotificationBestEffort({
+      supabase: admin,
+      userId: recipientUserId,
+      notificationId: String(insertedNotification.id),
+      kind: 'message',
+      payload: {
+        message_id: messageId,
+        thread_id: senderProfileId,
+        preview,
+      },
+    });
+  }
 }
 
 export const GET = withAuth(async (_req: NextRequest, { supabase, user }, routeContext) => {

--- a/app/api/feed/comments/route.ts
+++ b/app/api/feed/comments/route.ts
@@ -28,6 +28,47 @@ function sanitizeBody(raw: unknown) {
   return text.slice(0, MAX_LEN);
 }
 
+function cleanName(value: unknown) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length ? normalized : null;
+}
+
+function toPushPreview(value: unknown) {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, 120);
+}
+
+async function resolveActorPublicName(client: any, actorProfileId: string | null, actorProfile?: any) {
+  if (!actorProfileId) return 'Qualcuno';
+
+  const baseProfile = actorProfile?.id ? actorProfile : null;
+  const baseName = cleanName(baseProfile?.display_name) || cleanName(baseProfile?.full_name);
+  const accountType = String(baseProfile?.account_type ?? '').toLowerCase();
+
+  if (accountType === 'club') {
+    const { data: club } = await client.from('clubs_view').select('display_name').eq('id', actorProfileId).maybeSingle();
+    return cleanName(club?.display_name) || baseName || 'Qualcuno';
+  }
+
+  if (accountType === 'athlete') {
+    const { data: athlete } = await client
+      .from('athletes_view')
+      .select('display_name, full_name')
+      .eq('id', actorProfileId)
+      .maybeSingle();
+    return cleanName(athlete?.display_name) || cleanName(athlete?.full_name) || baseName || 'Qualcuno';
+  }
+
+  if (baseName) return baseName;
+  const { data: profile } = await client
+    .from('profiles')
+    .select('display_name, full_name')
+    .eq('id', actorProfileId)
+    .maybeSingle();
+  return cleanName(profile?.display_name) || cleanName(profile?.full_name) || 'Qualcuno';
+}
+
 async function buildClubVerificationMap(supabase: Awaited<ReturnType<typeof getSupabaseServerClient>>, clubIds: string[]) {
   if (!clubIds.length) return new Map<string, boolean>();
   try {
@@ -212,6 +253,8 @@ export async function POST(req: NextRequest) {
 
     const actorByUser = await getProfileByUserId(notificationsClient, auth.user.id, { activeOnly: true });
     const actorProfileId = actorByUser?.id ? String(actorByUser.id) : null;
+    const actorName = await resolveActorPublicName(notificationsClient, actorProfileId, actorByUser);
+    const commentPreview = toPushPreview(body);
 
     const isSelfByUser = !!recipientUserId && recipientUserId === auth.user.id;
     const isSelfByProfile = !!recipientProfileId && !!actorProfileId && recipientProfileId === actorProfileId;
@@ -263,7 +306,9 @@ export async function POST(req: NextRequest) {
           payload: {
             post_id: postId,
             comment_id: data.id,
-            body,
+            actor_name: actorName,
+            comment_preview: commentPreview,
+            preview: commentPreview,
           },
         });
         console.info('[api/feed/comments][POST] push dispatch summary', {

--- a/app/api/feed/reactions/route.ts
+++ b/app/api/feed/reactions/route.ts
@@ -22,6 +22,42 @@ export const runtime = 'nodejs';
 
 type ReactionType = 'like' | 'love' | 'care' | 'angry';
 
+function cleanName(value: unknown) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length ? normalized : null;
+}
+
+async function resolveActorPublicName(client: any, actorProfileId: string | null, actorProfile?: any) {
+  if (!actorProfileId) return 'Qualcuno';
+
+  const baseProfile = actorProfile?.id ? actorProfile : null;
+  const baseName = cleanName(baseProfile?.display_name) || cleanName(baseProfile?.full_name);
+  const accountType = String(baseProfile?.account_type ?? '').toLowerCase();
+
+  if (accountType === 'club') {
+    const { data: club } = await client.from('clubs_view').select('display_name').eq('id', actorProfileId).maybeSingle();
+    return cleanName(club?.display_name) || baseName || 'Qualcuno';
+  }
+
+  if (accountType === 'athlete') {
+    const { data: athlete } = await client
+      .from('athletes_view')
+      .select('display_name, full_name')
+      .eq('id', actorProfileId)
+      .maybeSingle();
+    return cleanName(athlete?.display_name) || cleanName(athlete?.full_name) || baseName || 'Qualcuno';
+  }
+
+  if (baseName) return baseName;
+  const { data: profile } = await client
+    .from('profiles')
+    .select('display_name, full_name')
+    .eq('id', actorProfileId)
+    .maybeSingle();
+  return cleanName(profile?.display_name) || cleanName(profile?.full_name) || 'Qualcuno';
+}
+
 function isMissingTable(err?: any) {
   const msg = (err?.message || '').toString();
   return /post_reactions/.test(msg) && /does not exist/i.test(msg);
@@ -201,6 +237,7 @@ export async function POST(req: NextRequest) {
 
         const actorByUser = await getProfileByUserId(notificationsClient, userRes.user.id, { activeOnly: true });
         const actorProfileId = actorByUser?.id ? String(actorByUser.id) : null;
+        const actorName = await resolveActorPublicName(notificationsClient, actorProfileId, actorByUser);
 
         const isSelfByUser = !!recipientUserId && recipientUserId === userRes.user.id;
         const isSelfByProfile = !!recipientProfileId && !!actorProfileId && recipientProfileId === actorProfileId;
@@ -251,6 +288,7 @@ export async function POST(req: NextRequest) {
               payload: {
                 post_id: postId,
                 reaction: validReaction,
+                actor_name: actorName,
               },
             });
             console.info('[feed/reactions][POST] push dispatch summary', {

--- a/lib/push/sendExpoPush.ts
+++ b/lib/push/sendExpoPush.ts
@@ -13,7 +13,7 @@ type SendPushParams = {
   payload?: Record<string, any> | null;
 };
 
-const EXCLUDED_KINDS = new Set<string>();
+const EXCLUDED_KINDS = new Set<string>([]);
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
 
 function createSummary(partial?: Partial<PushSummary>): PushSummary {

--- a/lib/push/sendExpoPush.ts
+++ b/lib/push/sendExpoPush.ts
@@ -43,13 +43,28 @@ function sanitizeSenderName(value: unknown) {
   return value.trim().slice(0, 80);
 }
 
+function toReactionLabel(value: unknown) {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (normalized === 'like') return 'Like';
+  if (normalized === 'love') return 'Love';
+  if (normalized === 'care') return 'Supporto';
+  if (normalized === 'angry') return 'Arrabbiato';
+  return 'Reazione';
+}
+
 function buildTitle(kind: string, payload?: Record<string, any> | null) {
   if (kind === 'message' || kind === 'new_message') {
     const senderName = sanitizeSenderName(payload?.sender_name);
     return senderName ? `Nuovo messaggio da ${senderName}` : 'Nuovo messaggio';
   }
-  if (kind === 'new_comment') return 'Nuovo commento';
-  if (kind === 'new_reaction') return 'Nuova reazione';
+  if (kind === 'new_comment') {
+    const actorName = sanitizeSenderName(payload?.actor_name) || 'Qualcuno';
+    return `${actorName} ha commentato il tuo post`;
+  }
+  if (kind === 'new_reaction') {
+    const actorName = sanitizeSenderName(payload?.actor_name) || 'Qualcuno';
+    return `${actorName} ha reagito al tuo post`;
+  }
   if (kind === 'application_received') return 'Nuova candidatura';
   if (kind === 'application_status') return 'Aggiornamento candidatura';
   return 'Nuova notifica';
@@ -60,21 +75,24 @@ function buildBody(kind: string, payload?: Record<string, any> | null) {
     const preview = sanitizePreview(payload?.preview ?? payload?.body);
     return preview || 'Hai ricevuto un nuovo messaggio.';
   }
+  if (kind === 'new_comment') {
+    const preview = sanitizePreview(payload?.comment_preview ?? payload?.preview ?? payload?.body);
+    return preview || 'Hai ricevuto un nuovo commento.';
+  }
+  if (kind === 'new_reaction') {
+    return toReactionLabel(payload?.reaction);
+  }
 
   const textFromPayload = [
-    payload?.comment_preview,
     payload?.body,
     payload?.opportunity_title,
     payload?.status,
-    payload?.reaction,
   ].find((value) => typeof value === 'string' && value.trim().length > 0);
 
   if (typeof textFromPayload === 'string' && textFromPayload.trim()) {
     return textFromPayload.trim().slice(0, 140);
   }
 
-  if (kind === 'new_comment') return 'Hai ricevuto un nuovo commento.';
-  if (kind === 'new_reaction') return 'Hai ricevuto una nuova reazione.';
   if (kind === 'application_received') return 'Hai ricevuto una nuova candidatura.';
   if (kind === 'application_status') return 'Lo stato della candidatura è stato aggiornato.';
   return 'Apri l’app per vedere i dettagli.';

--- a/lib/push/sendExpoPush.ts
+++ b/lib/push/sendExpoPush.ts
@@ -33,8 +33,21 @@ function toExpoToken(value: unknown): string | null {
   return null;
 }
 
-function buildTitle(kind: string) {
-  if (kind === 'message' || kind === 'new_message') return 'Nuovo messaggio';
+function sanitizePreview(value: unknown) {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, 120);
+}
+
+function sanitizeSenderName(value: unknown) {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, 80);
+}
+
+function buildTitle(kind: string, payload?: Record<string, any> | null) {
+  if (kind === 'message' || kind === 'new_message') {
+    const senderName = sanitizeSenderName(payload?.sender_name);
+    return senderName ? `Nuovo messaggio da ${senderName}` : 'Nuovo messaggio';
+  }
   if (kind === 'new_comment') return 'Nuovo commento';
   if (kind === 'new_reaction') return 'Nuova reazione';
   if (kind === 'application_received') return 'Nuova candidatura';
@@ -43,6 +56,11 @@ function buildTitle(kind: string) {
 }
 
 function buildBody(kind: string, payload?: Record<string, any> | null) {
+  if (kind === 'message' || kind === 'new_message') {
+    const preview = sanitizePreview(payload?.preview ?? payload?.body);
+    return preview || 'Hai ricevuto un nuovo messaggio.';
+  }
+
   const textFromPayload = [
     payload?.comment_preview,
     payload?.body,
@@ -55,7 +73,6 @@ function buildBody(kind: string, payload?: Record<string, any> | null) {
     return textFromPayload.trim().slice(0, 140);
   }
 
-  if (kind === 'message' || kind === 'new_message') return 'Hai ricevuto un nuovo messaggio.';
   if (kind === 'new_comment') return 'Hai ricevuto un nuovo commento.';
   if (kind === 'new_reaction') return 'Hai ricevuto una nuova reazione.';
   if (kind === 'application_received') return 'Hai ricevuto una nuova candidatura.';
@@ -99,7 +116,7 @@ export async function sendPushForNotificationBestEffort(params: SendPushParams):
       return createSummary({ skipped: 1 });
     }
 
-    const title = buildTitle(kind);
+    const title = buildTitle(kind, payload);
     const body = buildBody(kind, payload);
 
     let sent = 0;

--- a/lib/push/sendExpoPush.ts
+++ b/lib/push/sendExpoPush.ts
@@ -13,7 +13,7 @@ type SendPushParams = {
   payload?: Record<string, any> | null;
 };
 
-const EXCLUDED_KINDS = new Set<string>([]);
+const EXCLUDED_KINDS = new Set<string>();
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
 
 function createSummary(partial?: Partial<PushSummary>): PushSummary {

--- a/lib/push/sendExpoPush.ts
+++ b/lib/push/sendExpoPush.ts
@@ -13,7 +13,7 @@ type SendPushParams = {
   payload?: Record<string, any> | null;
 };
 
-const EXCLUDED_KINDS = new Set(['message', 'new_message']);
+const EXCLUDED_KINDS = new Set<string>();
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
 
 function createSummary(partial?: Partial<PushSummary>): PushSummary {
@@ -34,6 +34,7 @@ function toExpoToken(value: unknown): string | null {
 }
 
 function buildTitle(kind: string) {
+  if (kind === 'message' || kind === 'new_message') return 'Nuovo messaggio';
   if (kind === 'new_comment') return 'Nuovo commento';
   if (kind === 'new_reaction') return 'Nuova reazione';
   if (kind === 'application_received') return 'Nuova candidatura';
@@ -54,6 +55,7 @@ function buildBody(kind: string, payload?: Record<string, any> | null) {
     return textFromPayload.trim().slice(0, 140);
   }
 
+  if (kind === 'message' || kind === 'new_message') return 'Hai ricevuto un nuovo messaggio.';
   if (kind === 'new_comment') return 'Hai ricevuto un nuovo commento.';
   if (kind === 'new_reaction') return 'Hai ricevuto una nuova reazione.';
   if (kind === 'application_received') return 'Hai ricevuto una nuova candidatura.';


### PR DESCRIPTION
### Motivation
- Re-enable sending Expo push notifications for message events and provide localized Italian title and body for those notifications.

### Description
- Remove `'message'` and `'new_message'` from the excluded kinds, add handling for these kinds in `buildTitle` and `buildBody`, and use a typed empty `Set<string>()` in `lib/push/sendExpoPush.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f057ef78f8832b86c851c96ff439e6)