### PR TITLE
Configura Vercel Cron per flush grouped pushes e aggiungi GET handler

### DIFF
--- a/app/api/notifications/flush-grouped-pushes/route.ts
+++ b/app/api/notifications/flush-grouped-pushes/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { flushGroupedPostPushes } from '@/lib/push/groupedPostPushQueue';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 function isAuthorized(req: NextRequest) {
   const expected = process.env.CRON_SECRET?.trim();
@@ -12,7 +13,7 @@ function isAuthorized(req: NextRequest) {
   return token === expected;
 }
 
-export async function POST(req: NextRequest) {
+async function handleFlush(req: NextRequest) {
   if (!isAuthorized(req)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
@@ -24,4 +25,12 @@ export async function POST(req: NextRequest) {
 
   const results = await flushGroupedPostPushes(admin);
   return NextResponse.json({ ok: true, processed: results.length, results });
+}
+
+export async function GET(req: NextRequest) {
+  return handleFlush(req);
+}
+
+export async function POST(req: NextRequest) {
+  return handleFlush(req);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,11 @@
       "source": "/storage/:path*",
       "destination": "https://izzfjrcabtixxsrnkzro.supabase.co/storage/v1/object/public/:path*"
     }
+  ],
+  "crons": [
+    {
+      "path": "/api/notifications/flush-grouped-pushes",
+      "schedule": "* * * * *"
+    }
   ]
 }


### PR DESCRIPTION
### Motivation
- Aggiungere un job Cron su Vercel per eseguire periodicamente il flush dei grouped push.
- Consentire a Vercel Cron (che manda richieste GET) di invocare la stessa logica già esposta via POST.
- Garantire che la protezione con `Authorization: Bearer process.env.CRON_SECRET` rimanga invariata e che la route sia forzatamente dinamica.

### Description
- Aggiunta della sezione `crons` in `vercel.json` con il job `{ "path": "/api/notifications/flush-grouped-pushes", "schedule": "* * * * *" }` senza modificare le altre chiavi esistenti.
- Modifica di `app/api/notifications/flush-grouped-pushes/route.ts` per aggiungere `export const dynamic = 'force-dynamic'`.
- Refactoring della route per estrarre `handleFlush(req)` e riutilizzarla sia in `GET` che in `POST` mantenendo la stessa logica di autorizzazione.
- I file modificati sono `vercel.json` e `app/api/notifications/flush-grouped-pushes/route.ts`.

### Testing
- Eseguito `pnpm lint` e la lint è passata con successo.
- Eseguito `pnpm run build` che è fallito in questo ambiente a causa di errori di fetch esterni per Google Fonts (`Inter`, `Righteous`) durante il `next build`, quindi la build non ha concluso con successo qui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f210d57ec4832ba3395899b429351e)