### PR TITLE
feat(notifications): safe grouped push debounce rollout with diagnostics

### DIFF
--- a/app/api/feed/comments/route.ts
+++ b/app/api/feed/comments/route.ts
@@ -17,8 +17,10 @@ import {
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { getProfileByUserId } from '@/lib/api/profile';
 import { enqueueGroupedPostPush } from '@/lib/push/groupedPostPushQueue';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 
 export const runtime = 'nodejs';
+const GROUPED_PUSH_DEBOUNCE_ENABLED = process.env.GROUPED_PUSH_DEBOUNCE_ENABLED === 'true';
 
 const MAX_LEN = 800;
 
@@ -303,21 +305,38 @@ export async function POST(req: NextRequest) {
           message: notificationError.message,
         });
       } else if (insertedNotification?.id) {
-        await enqueueGroupedPostPush({
-          client: notificationsClient,
-          recipientUserId,
-          kind: 'new_comment',
-          postId,
-          actorName: actorName || 'Qualcuno',
-          latestNotificationId: Number(insertedNotification.id),
-          body: commentPreview,
-        });
-        console.info('[api/feed/comments][POST] grouped push queued', {
-          postId,
-          commentId: data.id,
-          notificationId: insertedNotification.id,
-          recipientUserId,
-        });
+        if (GROUPED_PUSH_DEBOUNCE_ENABLED) {
+          await enqueueGroupedPostPush({
+            client: notificationsClient,
+            recipientUserId,
+            kind: 'new_comment',
+            postId,
+            actorName: actorName || 'Qualcuno',
+            latestNotificationId: Number(insertedNotification.id),
+            body: commentPreview,
+          });
+          console.info('[api/feed/comments][POST] grouped push queued', {
+            postId,
+            commentId: data.id,
+            notificationId: insertedNotification.id,
+            recipientUserId,
+          });
+        } else {
+          const immediateSummary = await sendPushForNotificationBestEffort({
+            supabase: notificationsClient,
+            userId: recipientUserId,
+            notificationId: String(insertedNotification.id),
+            kind: 'new_comment',
+            payload: notificationPayload.payload,
+          });
+          console.info('[api/feed/comments][POST] immediate push sent (debounce disabled)', {
+            postId,
+            commentId: data.id,
+            notificationId: insertedNotification.id,
+            recipientUserId,
+            immediateSummary,
+          });
+        }
       }
     }
   } catch (notificationErr: any) {

--- a/app/api/feed/reactions/route.ts
+++ b/app/api/feed/reactions/route.ts
@@ -11,6 +11,7 @@ import { getSupabaseServerClient } from '@/lib/supabase/server';
 import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
 import { getProfileByUserId } from '@/lib/api/profile';
 import { enqueueGroupedPostPush } from '@/lib/push/groupedPostPushQueue';
+import { sendPushForNotificationBestEffort } from '@/lib/push/sendExpoPush';
 import {
   CreateReactionSchema,
   ReactionCountsQuerySchema,
@@ -19,6 +20,7 @@ import {
 } from '@/lib/validation/feed';
 
 export const runtime = 'nodejs';
+const GROUPED_PUSH_DEBOUNCE_ENABLED = process.env.GROUPED_PUSH_DEBOUNCE_ENABLED === 'true';
 
 type ReactionType = 'like' | 'love' | 'care' | 'angry';
 
@@ -281,20 +283,36 @@ export async function POST(req: NextRequest) {
               message: notificationError.message,
             });
           } else if (insertedNotification?.id) {
-            await enqueueGroupedPostPush({
-              client: notificationsClient,
-              recipientUserId,
-              kind: 'new_reaction',
-              postId,
-              actorName: actorName || 'Qualcuno',
-              latestNotificationId: Number(insertedNotification.id),
-              body: validReaction,
-            });
-            console.info('[feed/reactions][POST] grouped push queued', {
-              postId,
-              recipientUserId,
-              notificationId: insertedNotification.id,
-            });
+            if (GROUPED_PUSH_DEBOUNCE_ENABLED) {
+              await enqueueGroupedPostPush({
+                client: notificationsClient,
+                recipientUserId,
+                kind: 'new_reaction',
+                postId,
+                actorName: actorName || 'Qualcuno',
+                latestNotificationId: Number(insertedNotification.id),
+                body: validReaction,
+              });
+              console.info('[feed/reactions][POST] grouped push queued', {
+                postId,
+                recipientUserId,
+                notificationId: insertedNotification.id,
+              });
+            } else {
+              const immediateSummary = await sendPushForNotificationBestEffort({
+                supabase: notificationsClient,
+                userId: recipientUserId,
+                notificationId: String(insertedNotification.id),
+                kind: 'new_reaction',
+                payload: notificationPayload.payload,
+              });
+              console.info('[feed/reactions][POST] immediate push sent (debounce disabled)', {
+                postId,
+                recipientUserId,
+                notificationId: insertedNotification.id,
+                immediateSummary,
+              });
+            }
           }
         }
       } catch (notificationErr: any) {

--- a/app/api/notifications/flush-grouped-pushes/route.ts
+++ b/app/api/notifications/flush-grouped-pushes/route.ts
@@ -15,16 +15,49 @@ function isAuthorized(req: NextRequest) {
 
 async function handleFlush(req: NextRequest) {
   if (!isAuthorized(req)) {
+    console.warn('[api/notifications/flush-grouped-pushes] unauthorized request');
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const admin = getSupabaseAdminClientOrNull();
   if (!admin) {
+    console.error('[api/notifications/flush-grouped-pushes] missing admin client');
     return NextResponse.json({ error: 'Missing Supabase admin client' }, { status: 500 });
   }
 
+  const nowIso = new Date().toISOString();
+  const { count: pendingCount, error: pendingCountError } = await admin
+    .from('grouped_push_queue')
+    .select('*', { count: 'exact', head: true })
+    .is('sent_at', null)
+    .is('locked_at', null)
+    .lte('scheduled_at', nowIso);
+  if (pendingCountError) {
+    console.warn('[api/notifications/flush-grouped-pushes] pending count failed', { message: pendingCountError.message });
+  }
+  console.info('[api/notifications/flush-grouped-pushes] pending found', { pending: pendingCount ?? null });
+
   const results = await flushGroupedPostPushes(admin);
-  return NextResponse.json({ ok: true, processed: results.length, results });
+  let sent = 0;
+  let skipped = 0;
+  const errors: Array<{ id: any; error: string }> = [];
+  for (const item of results) {
+    if (item?.error) errors.push({ id: item?.id ?? null, error: item.error });
+    if (item?.summary?.sent) sent += Number(item.summary.sent) || 0;
+    if (item?.summary?.skipped) skipped += Number(item.summary.skipped) || 0;
+    if (item?.skipped) skipped += 1;
+  }
+  console.info('[api/notifications/flush-grouped-pushes] flush completed', {
+    pending: pendingCount ?? null,
+    processed: results.length,
+    sent,
+    skipped,
+    errors: errors.length,
+  });
+  if (errors.length) {
+    console.warn('[api/notifications/flush-grouped-pushes] item errors', { errors });
+  }
+  return NextResponse.json({ ok: true, pending: pendingCount ?? null, processed: results.length, sent, skipped, errors, results });
 }
 
 export async function GET(req: NextRequest) {

--- a/lib/push/groupedPostPushQueue.ts
+++ b/lib/push/groupedPostPushQueue.ts
@@ -50,7 +50,7 @@ export async function enqueueGroupedPostPush(params: {
   const safeActorName = cleanName(actorName) || 'Qualcuno';
   const safeBody = typeof body === 'string' ? body.trim().slice(0, 120) : '';
 
-  const { data: existing } = await client
+  const { data: existing, error: existingError } = await client
     .from('grouped_push_queue')
     .select('id, group_count, actors, payload')
     .eq('recipient_user_id', recipientUserId)
@@ -58,6 +58,14 @@ export async function enqueueGroupedPostPush(params: {
     .eq('post_id', postId)
     .is('sent_at', null)
     .maybeSingle();
+  if (existingError) {
+    console.warn('[push/groupedPostPushQueue] failed to read existing queue row', {
+      recipientUserId,
+      kind,
+      postId,
+      message: existingError.message,
+    });
+  }
 
   const existingActors = Array.isArray(existing?.actors) ? existing.actors : [];
   const actors = Array.from(new Set([safeActorName, ...existingActors].filter((v) => typeof v === 'string' && v.trim()))).slice(0, 8);
@@ -65,7 +73,7 @@ export async function enqueueGroupedPostPush(params: {
   const payload = buildPayload({ kind, postId, actorName: safeActorName, groupCount, actors, body: safeBody || undefined });
 
   if (existing?.id) {
-    await client
+    const { error: updateError } = await client
       .from('grouped_push_queue')
       .update({
         latest_notification_id: latestNotificationId,
@@ -77,10 +85,21 @@ export async function enqueueGroupedPostPush(params: {
       })
       .eq('id', existing.id)
       .is('sent_at', null);
+    if (updateError) {
+      console.warn('[push/groupedPostPushQueue] failed to update queue row', {
+        id: existing.id,
+        recipientUserId,
+        kind,
+        postId,
+        message: updateError.message,
+      });
+      throw updateError;
+    }
+    console.info('[push/groupedPostPushQueue] queue row updated', { id: existing.id, recipientUserId, kind, postId, groupCount });
     return;
   }
 
-  await client.from('grouped_push_queue').insert({
+  const { error: insertError } = await client.from('grouped_push_queue').insert({
     recipient_user_id: recipientUserId,
     kind,
     post_id: postId,
@@ -90,13 +109,23 @@ export async function enqueueGroupedPostPush(params: {
     payload,
     scheduled_at: scheduledAt,
   });
+  if (insertError) {
+    console.warn('[push/groupedPostPushQueue] failed to insert queue row', {
+      recipientUserId,
+      kind,
+      postId,
+      message: insertError.message,
+    });
+    throw insertError;
+  }
+  console.info('[push/groupedPostPushQueue] queue row inserted', { recipientUserId, kind, postId, groupCount: 1 });
 }
 
 export async function flushGroupedPostPushes(client: any) {
   const lockTs = new Date().toISOString();
   const nowIso = new Date().toISOString();
 
-  const { data: rows } = await client
+  const { data: rows, error: pendingError } = await client
     .from('grouped_push_queue')
     .select('*')
     .is('sent_at', null)
@@ -104,10 +133,14 @@ export async function flushGroupedPostPushes(client: any) {
     .lte('scheduled_at', nowIso)
     .order('scheduled_at', { ascending: true })
     .limit(100);
+  if (pendingError) {
+    console.warn('[push/groupedPostPushQueue] failed to fetch pending rows', { message: pendingError.message });
+    throw pendingError;
+  }
 
   const results: any[] = [];
   for (const row of rows ?? []) {
-    const { data: locked } = await client
+    const { data: locked, error: lockError } = await client
       .from('grouped_push_queue')
       .update({ locked_at: lockTs })
       .eq('id', row.id)
@@ -115,24 +148,40 @@ export async function flushGroupedPostPushes(client: any) {
       .is('locked_at', null)
       .select('id')
       .maybeSingle();
+    if (lockError) {
+      results.push({ id: row.id, skipped: true, reason: 'lock_error', message: lockError.message });
+      continue;
+    }
 
     if (!locked?.id) continue;
 
-    const summary = await sendPushForNotificationBestEffort({
-      supabase: client,
-      userId: row.recipient_user_id,
-      notificationId: String(row.latest_notification_id),
-      kind: row.kind,
-      payload: row.payload,
-    });
+    try {
+      const summary = await sendPushForNotificationBestEffort({
+        supabase: client,
+        userId: row.recipient_user_id,
+        notificationId: String(row.latest_notification_id),
+        kind: row.kind,
+        payload: row.payload,
+      });
 
-    await client
-      .from('grouped_push_queue')
-      .update({ sent_at: new Date().toISOString(), locked_at: null, last_result: summary })
-      .eq('id', row.id)
-      .is('sent_at', null);
+      await client
+        .from('grouped_push_queue')
+        .update({ sent_at: new Date().toISOString(), locked_at: null, last_result: summary })
+        .eq('id', row.id)
+        .is('sent_at', null);
 
-    results.push({ id: row.id, kind: row.kind, userId: row.recipient_user_id, summary });
+      results.push({ id: row.id, kind: row.kind, userId: row.recipient_user_id, summary });
+    } catch (error: any) {
+      await client
+        .from('grouped_push_queue')
+        .update({
+          locked_at: null,
+          last_result: { error: error?.message ?? 'unknown_error', failed_at: new Date().toISOString() },
+        })
+        .eq('id', row.id)
+        .is('sent_at', null);
+      results.push({ id: row.id, kind: row.kind, userId: row.recipient_user_id, error: error?.message ?? 'unknown_error' });
+    }
   }
 
   return results;


### PR DESCRIPTION
### Motivation
- Il debounce precedente ha causato blackout delle push e serve un rollout sicuro che mantenga le notifiche immediate finché il flush non è verificato.
- Serve diagnostica chiara e resilienza per isolare errori per singolo item e permettere un rollout osservabile senza interrompere gli utenti.
- L'endpoint di flush deve rimanere protetto da `CRON_SECRET` e supportare chiamate manuali/cron per verifiche operative.

### Description
- Introdotto flag di rollout `GROUPED_PUSH_DEBOUNCE_ENABLED` valutato come `process.env.GROUPED_PUSH_DEBOUNCE_ENABLED === 'true'` che abilita l'enqueueing; default mantiene il comportamento di push immediato.
- Nei file `app/api/feed/comments/route.ts` e `app/api/feed/reactions/route.ts` la pipeline ora condiziona l'enqueue su `grouped_push_queue` oppure invoca immediatamente `sendPushForNotificationBestEffort` quando il flag è disabilitato.
- Rinforzata la coda in `lib/push/groupedPostPushQueue.ts` con logging su read/update/insert, gestione degli errori per singolo item, controllo lock e aggiornamento `last_result` senza bloccare gli altri elementi.
- Migliorata la route di flush in `app/api/notifications/flush-grouped-pushes/route.ts` con supporto `GET`/`POST`, `export const runtime = 'nodejs'`, `export const dynamic = 'force-dynamic'`, controllo `Authorization: Bearer <CRON_SECRET>`, conteggio pending e log/report dettagliato di processed/sent/skipped/errors.

### Testing
- Eseguito `pnpm install --frozen-lockfile` che è terminato con successo in ambiente di lavoro.
- Eseguito `pnpm lint` che è passato con successo senza warning.
- Eseguito `pnpm run build` che è fallito per errori di fetch esterno di Google Fonts durante il build Next.js/Turbopack, errore di rete esterno non correlato alle modifiche applicate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f537f68c832b85bd797c5cff6fa2)