### PR TITLE
Make reactions resilient and add long-press reaction picker for touch devices

### DIFF
--- a/app/(dashboard)/feed/page.tsx
+++ b/app/(dashboard)/feed/page.tsx
@@ -14,6 +14,7 @@ import AdSlot from '@/components/ads/AdSlot';
 import OpportunityCard from '@/components/opportunities/OpportunityCard';
 import {
   computeOptimistic,
+  computeNextMine,
   createDefaultReaction,
   defaultReactionState,
   REACTION_ORDER,
@@ -53,6 +54,7 @@ export default function FeedPage() {
   const [reactionError, setReactionError] = useState<string | null>(null);
   const [commentCounts, setCommentCounts] = useState<Record<string, number>>({});
   const [pickerFor, setPickerFor] = useState<string | null>(null);
+  const reactionsRef = useRef<Record<string, ReactionState>>({});
   const seenPostIds = useRef<Set<string>>(new Set());
   const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
   const headingId = 'feed-heading';
@@ -181,9 +183,10 @@ export default function FeedPage() {
   const toggleReaction = useCallback(
     async (postId: string, type: ReactionType) => {
       const key = String(postId);
-      const prev = reactions[key] ?? createDefaultReaction();
-      const nextMine = prev.mine === type ? null : type;
+      const prev = reactionsRef.current[key] ?? createDefaultReaction();
+      const nextMine = computeNextMine(prev.mine, type);
       const next = computeOptimistic(prev, nextMine);
+      reactionsRef.current = { ...reactionsRef.current, [key]: next };
       setReactions((curr) => ({ ...curr, [key]: next }));
       setReactionError(null);
 
@@ -211,9 +214,12 @@ export default function FeedPage() {
           ? (json.mine as ReactionType)
           : null;
 
-        setReactions((curr) => ({ ...curr, [key]: { counts, mine: mineReaction } }));
+        const settled = { counts, mine: mineReaction };
+        reactionsRef.current = { ...reactionsRef.current, [key]: settled };
+        setReactions((curr) => ({ ...curr, [key]: settled }));
       } catch (error: any) {
         console.warn('toggleReaction failed', error);
+        reactionsRef.current = { ...reactionsRef.current, [key]: prev };
         setReactions((curr) => ({ ...curr, [key]: prev }));
         if (String(error?.message || '').includes('missing_table_post_reactions')) {
           setReactionError('Aggiungi la tabella post_reactions (vedi supabase/migrations/20251018_fix_notifications_follows_post_reactions.sql).');
@@ -224,8 +230,12 @@ export default function FeedPage() {
         }
       }
     },
-    [reactions],
+    [],
   );
+
+  useEffect(() => {
+    reactionsRef.current = reactions;
+  }, [reactions]);
 
   useEffect(() => {
     setReactions({});

--- a/app/posts/[id]/PostClient.tsx
+++ b/app/posts/[id]/PostClient.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PostCard } from '@/components/feed/PostCard';
 import {
   computeOptimistic,
+  computeNextMine,
   createDefaultReaction,
   REACTION_ORDER,
   type FeedPost,
@@ -23,6 +24,7 @@ export function PostClient({ post, currentUserId }: Props) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [deleted, setDeleted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const reactionRef = useRef(reaction);
 
   useEffect(() => {
     const id = String(item.id);
@@ -77,13 +79,17 @@ export function PostClient({ post, currentUserId }: Props) {
 
   const toggleReaction = useCallback(
     async (type: ReactionType) => {
-      setReaction((prev) => computeOptimistic(prev, prev.mine === type ? null : type));
+      const prev = reactionRef.current;
+      const nextMine = computeNextMine(prev.mine, type);
+      const optimistic = computeOptimistic(prev, nextMine);
+      reactionRef.current = optimistic;
+      setReaction(optimistic);
       try {
         const res = await fetch('/api/feed/reactions', {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ postId: item.id, reaction: reaction.mine === type ? null : type }),
+          body: JSON.stringify({ postId: item.id, reaction: nextMine }),
         });
         const json = await res.json().catch(() => ({}));
         if (!res.ok || !json?.ok) throw new Error(json?.error || 'reaction_error');
@@ -96,13 +102,21 @@ export function PostClient({ post, currentUserId }: Props) {
           }
         });
         const mineReaction = REACTION_ORDER.includes(json?.mine as ReactionType) ? (json.mine as ReactionType) : null;
-        setReaction({ ...next, mine: mineReaction });
+        const settled = { ...next, mine: mineReaction };
+        reactionRef.current = settled;
+        setReaction(settled);
       } catch (e: any) {
+        reactionRef.current = prev;
+        setReaction(prev);
         setError(e?.message || 'Reazioni non disponibili');
       }
     },
-    [item.id, reaction.mine],
+    [item.id],
   );
+
+  useEffect(() => {
+    reactionRef.current = reaction;
+  }, [reaction]);
 
   if (deleted) {
     return <div className="glass-panel p-4 text-sm text-neutral-700">Post eliminato o non disponibile.</div>;

--- a/components/feed/PostCard.tsx
+++ b/components/feed/PostCard.tsx
@@ -423,7 +423,6 @@ export function PostCard({
 
       <div
         className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-3 text-sm font-semibold text-neutral-700"
-        onMouseLeave={onClosePicker}
       >
         <div className="relative inline-flex items-center gap-2">
           <button
@@ -472,7 +471,12 @@ export function PostCard({
           </button>
 
           {pickerOpen && (
-            <div className="absolute left-0 top-full z-10 mt-1 flex gap-2 rounded-full border border-slate-100 bg-white px-2 py-1 shadow-lg">
+            <div
+              className="absolute left-0 top-full z-10 pt-1"
+              onMouseLeave={onClosePicker}
+              onMouseEnter={onOpenPicker}
+            >
+              <div className="flex gap-2 rounded-full border border-slate-100 bg-white px-2 py-1 shadow-lg">
               {REACTION_ORDER.map((r) => (
                 <button
                   key={r}
@@ -489,6 +493,7 @@ export function PostCard({
                   <span className="sr-only">{r}</span>
                 </button>
               ))}
+              </div>
             </div>
           )}
         </div>

--- a/components/feed/PostCard.tsx
+++ b/components/feed/PostCard.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CommentsSection } from '@/components/feed/CommentsSection';
 import { PostIconDelete, PostIconEdit, PostIconShare } from '@/components/icons/PostActionIcons';
 import { PostMedia } from '@/components/feed/PostMedia';
@@ -83,6 +83,7 @@ export function PostCard({
   onToggleReaction,
   onCommentCountChange,
 }: PostCardProps) {
+  const LONG_PRESS_MS = 500;
   const isEvent = (post.kind ?? 'normal') === 'event';
   const eventDetails = post.event_payload;
   const baseDescription = post.content ?? post.text ?? '';
@@ -125,6 +126,15 @@ export function PostCard({
   const errorId = error ? `post-error-${post.id}` : undefined;
   const eventDateLabel = eventDetails?.date ? formatEventDate(eventDetails.date) : null;
   const [commentSignal, setCommentSignal] = useState(0);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTriggeredRef = useRef(false);
+
+  function clearLongPressTimer() {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }
 
   const shareTitle = isEvent ? eventDetails?.title ?? 'Evento del club' : 'Post del feed';
   const shareMessage = useMemo(() => {
@@ -180,6 +190,10 @@ export function PostCard({
   useEffect(() => {
     if (!editing) setText(description);
   }, [description, editing, post]);
+
+  useEffect(() => {
+    return () => clearLongPressTimer();
+  }, []);
 
   async function saveEdit() {
     const payload = text.trim();
@@ -414,8 +428,29 @@ export function PostCard({
         <div className="relative inline-flex items-center gap-2">
           <button
             type="button"
-            onClick={() => onToggleReaction('like')}
+            onClick={() => {
+              if (longPressTriggeredRef.current) {
+                longPressTriggeredRef.current = false;
+                return;
+              }
+              onToggleReaction('like');
+            }}
             onMouseEnter={onOpenPicker}
+            onTouchStart={() => {
+              longPressTriggeredRef.current = false;
+              clearLongPressTimer();
+              longPressTimerRef.current = setTimeout(() => {
+                longPressTriggeredRef.current = true;
+                onOpenPicker();
+              }, LONG_PRESS_MS);
+            }}
+            onTouchEnd={() => {
+              clearLongPressTimer();
+            }}
+            onTouchCancel={() => {
+              clearLongPressTimer();
+              longPressTriggeredRef.current = false;
+            }}
             className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 transition ${
               reaction.mine
                 ? 'bg-[var(--brand)]/10 text-[var(--brand)] shadow-inner'

--- a/components/feed/PublicAuthorFeed.tsx
+++ b/components/feed/PublicAuthorFeed.tsx
@@ -1,11 +1,12 @@
 // components/feed/PublicAuthorFeed.tsx
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PostCard } from '@/components/feed/PostCard';
 import {
   REACTION_ORDER,
   computeOptimistic,
+  computeNextMine,
   createDefaultReaction,
   defaultReactionState,
   normalizePost,
@@ -28,6 +29,7 @@ export default function PublicAuthorFeed({ authorId, fallbackAuthorIds = [] }: P
   const [pickerFor, setPickerFor] = useState<string | null>(null);
   const [commentCounts, setCommentCounts] = useState<Record<string, number>>({});
   const [reactionError, setReactionError] = useState<string | null>(null);
+  const reactionsRef = useRef<Record<string, ReactionState>>({});
 
   const loadReactions = useCallback(async (ids: string[]) => {
     if (!ids.length) return;
@@ -134,9 +136,10 @@ export default function PublicAuthorFeed({ authorId, fallbackAuthorIds = [] }: P
   }, [authorId, fallbackAuthorIds, loadCommentCounts, loadReactions]);
 
   async function toggleReaction(postId: string, type: ReactionType) {
-    const prev = reactions[postId] ?? createDefaultReaction();
-    const nextMine = prev.mine === type ? null : type;
+    const prev = reactionsRef.current[postId] ?? createDefaultReaction();
+    const nextMine = computeNextMine(prev.mine, type);
     const next = computeOptimistic(prev, nextMine);
+    reactionsRef.current = { ...reactionsRef.current, [postId]: next };
     setReactions((curr) => ({ ...curr, [postId]: next }));
     try {
       const res = await fetch('/api/feed/reactions', {
@@ -158,8 +161,11 @@ export default function PublicAuthorFeed({ authorId, fallbackAuthorIds = [] }: P
       const mineReaction = REACTION_ORDER.includes(json.mine as ReactionType)
         ? (json.mine as ReactionType)
         : null;
-      setReactions((curr) => ({ ...curr, [postId]: { counts, mine: mineReaction } }));
+      const settled = { counts, mine: mineReaction };
+      reactionsRef.current = { ...reactionsRef.current, [postId]: settled };
+      setReactions((curr) => ({ ...curr, [postId]: settled }));
     } catch (err: any) {
+      reactionsRef.current = { ...reactionsRef.current, [postId]: prev };
       setReactions((curr) => ({ ...curr, [postId]: prev }));
       if (String(err?.message || '').includes('not_authenticated')) {
         setReactionError('Accedi per reagire ai post.');
@@ -168,6 +174,10 @@ export default function PublicAuthorFeed({ authorId, fallbackAuthorIds = [] }: P
       }
     }
   }
+
+  useEffect(() => {
+    reactionsRef.current = reactions;
+  }, [reactions]);
 
   return (
     <div className="space-y-3">

--- a/components/feed/postShared.ts
+++ b/components/feed/postShared.ts
@@ -105,6 +105,10 @@ export function computeOptimistic(prev: ReactionState, nextMine: ReactionType | 
   return { counts, mine: nextMine };
 }
 
+export function computeNextMine(currentMine: ReactionType | null, selected: ReactionType): ReactionType | null {
+  return currentMine === selected ? null : selected;
+}
+
 export function firstUrl(text?: string | null): string | null {
   if (!text) return null;
   const match = text.match(/https?:\/\/[^\s]+/i);


### PR DESCRIPTION
### Motivation
- Avoid stale state/closure issues when toggling reactions by keeping a ref-backed source of truth for reaction states and computing the next reaction deterministically.  
- Provide a better mobile experience by supporting long-press to open the reaction picker and preventing the click action from firing after a long-press.  
- Centralize logic for computing the next `mine` value for reactions.

### Description
- Added `computeNextMine` helper to `components/feed/postShared.ts` and used it where reaction toggles compute the next user reaction.  
- Replaced several direct state reads in reaction handlers with ref-backed values and kept those refs in sync with state in `app/(dashboard)/feed/page.tsx`, `app/posts/[id]/PostClient.tsx`, and `components/feed/PublicAuthorFeed.tsx` to prevent race conditions and stale closures when performing optimistic updates and settling server responses.  
- Updated reaction `toggleReaction` implementations to write optimistic updates to the ref and to restore the ref on error, and reduced hook dependency arrays where appropriate (e.g. `useCallback` now depends only on stable inputs).  
- Implemented long-press handling in `components/feed/PostCard.tsx` to open the reaction picker on touch devices after `LONG_PRESS_MS` and to suppress the normal click if a long-press was triggered, with proper timer cleanup on unmount/touch cancel.  

### Testing
- Performed a production build with `next build` which completed successfully.  
- Ran the test suite with `npm test` and all tests passed.  
- Ran lint checks with `npm run lint` which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3177d0bb8832ba5c92ca7e5bd897c)