### PR TITLE
Aggiungi contatori pubblici reali (club/player/fan) su /signup

### DIFF
--- a/app/api/public/signup-stats/route.ts
+++ b/app/api/public/signup-stats/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdminClientOrNull } from '@/lib/supabase/admin';
+import { getSupabaseServerClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+
+type SignupStatsResponse = {
+  clubs: number;
+  players: number;
+  fans: number;
+};
+
+const EMPTY_STATS: SignupStatsResponse = { clubs: 0, players: 0, fans: 0 };
+
+async function countProfilesByRole(role: 'club' | 'fan' | 'athlete') {
+  const admin = getSupabaseAdminClientOrNull();
+
+  if (admin) {
+    const { count, error } = await admin
+      .from('profiles')
+      .select('id', { count: 'exact', head: true })
+      .eq('account_type', role);
+
+    if (error) throw error;
+    return count ?? 0;
+  }
+
+  const supabase = await getSupabaseServerClient();
+  const { count, error } = await supabase
+    .from('profiles')
+    .select('id', { count: 'exact', head: true })
+    .eq('account_type', role);
+
+  if (error) throw error;
+  return count ?? 0;
+}
+
+export async function GET() {
+  try {
+    const [clubs, players, fans] = await Promise.all([
+      countProfilesByRole('club'),
+      countProfilesByRole('athlete'),
+      countProfilesByRole('fan'),
+    ]);
+
+    return NextResponse.json<SignupStatsResponse>({ clubs, players, fans });
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('[api/public/signup-stats] failed to fetch counters', error);
+    }
+    return NextResponse.json<SignupStatsResponse>(EMPTY_STATS, { status: 200 });
+  }
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -29,6 +29,7 @@ export default function SignupPage() {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [ok, setOk] = useState<string | null>(null);
+  const [signupStats, setSignupStats] = useState<{ clubs: number; players: number; fans: number } | null>(null);
 
   // se già loggato → lascia che sia il middleware a instradare:
   // - account_type mancante => /onboarding/choose-role
@@ -46,6 +47,35 @@ export default function SignupPage() {
   // mostra il bottone Google solo quando ha senso
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
   const oauthReady = useMemo(() => HAS_ENV && Boolean(origin), [origin]);
+
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadStats = async () => {
+      try {
+        const response = await fetch('/api/public/signup-stats', { cache: 'no-store' });
+        if (!response.ok) return;
+        const data = await response.json();
+        if (!mounted) return;
+        setSignupStats({
+          clubs: Number(data?.clubs ?? 0),
+          players: Number(data?.players ?? 0),
+          fans: Number(data?.fans ?? 0),
+        });
+      } catch {
+        // fallback silenzioso: non blocchiamo la pagina signup
+      }
+    };
+
+    loadStats();
+    const timer = window.setInterval(loadStats, 3000);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(timer);
+    };
+  }, []);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -100,9 +130,15 @@ export default function SignupPage() {
               <li>• Ricevi candidature e messaggi in app</li>
             </ul>
             <p className="text-lg leading-relaxed text-slate-800">
-              Oppure registrati e connettiti come <b>FAN</b> e segui i tuoi Club o Player preferiti e interagisci con
-              loro
+              Oppure registrati e connettiti come <b>FAN</b> e segui i tuoi <b>CLUB</b> o <b>PLAYER</b> preferiti e
+              interagisci con loro
             </p>
+            <div className="rounded-2xl border border-[#00527a1f] bg-white/70 p-4 text-sm text-slate-800">
+              <p className="font-semibold text-[#00527a]">Community in crescita</p>
+              <p>Club iscritti: {signupStats ? signupStats.clubs : '—'}</p>
+              <p>Player iscritti: {signupStats ? signupStats.players : '—'}</p>
+              <p>Fan iscritti: {signupStats ? signupStats.fans : '—'}</p>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation
- Mostrare sulla pagina pubblica `/signup` un piccolo contatore aggregato e pubblico con numeri reali di Club, Player e Fan aggiornati ogni 3 secondi, senza esporre dati personali e senza toccare la logica di auth/onboarding.

### Description
- Aggiunto endpoint pubblico read-only `app/api/public/signup-stats/route.ts` che restituisce `{ clubs, players, fans }` e conteggia `profiles.account_type` usando prima il client admin di Supabase e in fallback il client server, normalizzando il ruolo `athlete` in `players` nel payload.
- L'endpoint è progettato per restituire solo conteggi aggregati e per degradare in modo sicuro restituendo zeri con `200` in caso di errore, senza esporre PII.
- Aggiornata la UI `app/signup/page.tsx` per effettuare una chiamata a `/api/public/signup-stats` al mount e fare polling ogni `3000ms`, mostrando un fallback non invasivo (`—`) e gestendo gli errori silenziosamente; inoltre sono stati messi in bold `CLUB / PLAYER / FAN` nel testo marketing come richiesto.
- File creati/modificati: `app/api/public/signup-stats/route.ts` (nuovo) e `app/signup/page.tsx` (modificato).

### Testing
- Eseguito `pnpm lint` e la verifica lint è passata con esito positivo.
- Eseguito `pnpm run build` che ha fallito in questo ambiente a causa di fetch delle Google Fonts (`Inter`/`Righteous`) durante la build, errore di rete esterno all'implementazione applicativa e non indicativo di regressioni nel codice aggiunto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32e7743c4832b8a162b78ac3b34c5)