### PR TITLE
Add Tuttocampo extractor script for amateur and youth teams

### DIFF
--- a/data/tuttocampo/.gitkeep
+++ b/data/tuttocampo/.gitkeep
@@ -1,0 +1,1 @@
+# keep directory tracked

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit --pretty false --project tsconfig.json",
     "dev:check": "pnpm lint && pnpm typecheck",
     "ci:check": "pnpm lint && pnpm typecheck && pnpm run build",
-    "test:e2e": "node --test tests/e2e/**/*.test.mjs"
+    "test:e2e": "node --test tests/e2e/**/*.test.mjs",
+    "extract:tuttocampo": "tsx scripts/extract-tuttocampo-teams.ts"
   },
   "dependencies": {
     "@react-email/render": "^1.3.1",
@@ -24,7 +25,9 @@
     "react-easy-crop": "^5.5.3",
     "require-in-the-middle": "7.5.2",
     "resend": "^6.0.1",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "cheerio": "^1.1.2",
+    "fast-xml-parser": "^5.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -41,7 +44,8 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "typescript-eslint": "^8.41.0"
+    "typescript-eslint": "^8.41.0",
+    "tsx": "^4.20.6"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev:check": "pnpm lint && pnpm typecheck",
     "ci:check": "pnpm lint && pnpm typecheck && pnpm run build",
     "test:e2e": "node --test tests/e2e/**/*.test.mjs",
-    "extract:tuttocampo": "tsx scripts/extract-tuttocampo-teams.ts"
+    "extract:tuttocampo": "tsx scripts/extract-tuttocampo-teams.ts",
+    "extract:tuttocampo:local": "tsx scripts/extract-tuttocampo-teams.ts --sitemap-file=data/tuttocampo/Index2025_26.xml"
   },
   "dependencies": {
     "@react-email/render": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2
         version: 2.58.0
+      cheerio:
+        specifier: ^1.1.2
+        version: 1.2.0
+      fast-xml-parser:
+        specifier: ^5.3.1
+        version: 5.7.2
       import-in-the-middle:
         specifier: ^1.14.4
         version: 1.14.4
@@ -87,6 +93,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.13
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.2
@@ -175,6 +184,162 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -435,6 +600,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1428,6 +1596,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1473,6 +1644,13 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -1517,6 +1695,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1603,12 +1788,23 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.24.0:
@@ -1645,6 +1841,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1813,6 +2014,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1959,12 +2167,19 @@ packages:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2377,6 +2592,9 @@ packages:
   normalize-wheel@1.0.1:
     resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2429,12 +2647,25 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2626,6 +2857,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -2744,6 +2978,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2824,6 +3061,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2867,6 +3109,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
 
@@ -2909,6 +3155,15 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3086,6 +3341,84 @@ snapshots:
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.6.0))':
@@ -3296,6 +3629,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4434,6 +4769,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -4488,6 +4825,29 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -4529,6 +4889,16 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
 
   csstype@3.1.3: {}
 
@@ -4612,12 +4982,21 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -4721,6 +5100,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -4964,6 +5372,17 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5115,6 +5534,13 @@ snapshots:
       htmlparser2: 8.0.2
       selderee: 0.11.0
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@8.0.2:
     dependencies:
       domelementtype: 2.3.0
@@ -5128,6 +5554,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -5497,6 +5927,10 @@ snapshots:
 
   normalize-wheel@1.0.1: {}
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -5566,12 +6000,27 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
       peberminta: 0.9.0
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -5783,6 +6232,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.26.0: {}
 
   schema-utils@4.3.2:
@@ -5966,6 +6417,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.2.3: {}
+
   styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
@@ -6035,6 +6488,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -6095,6 +6555,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unplugin@1.0.1:
     dependencies:
@@ -6181,6 +6643,12 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:

--- a/scripts/extract-tuttocampo-teams.ts
+++ b/scripts/extract-tuttocampo-teams.ts
@@ -1,0 +1,258 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { XMLParser } from 'fast-xml-parser';
+import * as cheerio from 'cheerio';
+
+const SITEMAP_INDEX_URL = 'https://www.tuttocampo.it/Sitemap/Index2025_26.xml';
+const REQUEST_INTERVAL_MS = 1500;
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; TuttocampoTeamsExtractor/1.0; +https://www.tuttocampo.it/)';
+
+const OUTPUT_DIR = path.join(process.cwd(), 'data', 'tuttocampo');
+const RAW_CSV_PATH = path.join(OUTPUT_DIR, 'teams_raw.csv');
+const UNIQUE_CSV_PATH = path.join(OUTPUT_DIR, 'teams_unique.csv');
+
+type RawTeamRow = {
+  originalName: string;
+  url: string;
+};
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  parseTagValue: true,
+  trimValues: true,
+});
+
+let lastRequestTimestamp = 0;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function rateLimitedFetch(url: string): Promise<Response> {
+  const now = Date.now();
+  const elapsed = now - lastRequestTimestamp;
+  if (elapsed < REQUEST_INTERVAL_MS) {
+    await sleep(REQUEST_INTERVAL_MS - elapsed);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': USER_AGENT,
+      accept: 'text/html,application/xml,text/xml;q=0.9,*/*;q=0.8',
+    },
+  });
+
+  lastRequestTimestamp = Date.now();
+  return response;
+}
+
+function asArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+async function fetchTextWithHandling(url: string): Promise<string | null> {
+  try {
+    const response = await rateLimitedFetch(url);
+
+    if (response.status === 403) {
+      console.warn(`[WARN] 403 Forbidden su: ${url}`);
+      return null;
+    }
+
+    if (!response.ok) {
+      console.warn(`[WARN] HTTP ${response.status} su: ${url}`);
+      return null;
+    }
+
+    return await response.text();
+  } catch (error) {
+    console.warn(`[WARN] Errore rete su ${url}:`, error);
+    return null;
+  }
+}
+
+function extractSitemapUrlsFromXml(xmlText: string): string[] {
+  const parsed = xmlParser.parse(xmlText);
+  const sitemapNodes = asArray<{ loc?: string }>(parsed?.sitemapindex?.sitemap);
+  return sitemapNodes
+    .map((node) => node?.loc?.trim())
+    .filter((loc): loc is string => Boolean(loc));
+}
+
+function extractPageUrlsFromSitemap(xmlText: string): string[] {
+  const parsed = xmlParser.parse(xmlText);
+  const urlNodes = asArray<{ loc?: string }>(parsed?.urlset?.url);
+  return urlNodes
+    .map((node) => node?.loc?.trim())
+    .filter((loc): loc is string => Boolean(loc));
+}
+
+function isLikelyTeamUrl(url: string): boolean {
+  const lower = url.toLowerCase();
+  if (!lower.includes('tuttocampo.it')) return false;
+
+  const includePatterns = [
+    '/squadra/',
+    '/team/',
+    '/societa/',
+    '/campionato/',
+    '/juniores',
+    '/under-',
+    '/allievi',
+    '/giovanissimi',
+    '/esordienti',
+    '/pulcini',
+    '/primi-calci',
+    '/serie-d',
+    '/eccellenza',
+    '/promozione',
+    '/prima-categoria',
+    '/seconda-categoria',
+    '/terza-categoria',
+  ];
+
+  return includePatterns.some((pattern) => lower.includes(pattern));
+}
+
+function extractTeamNameFromHtml(html: string): string | null {
+  const $ = cheerio.load(html);
+
+  const candidates = [
+    $('meta[property="og:title"]').attr('content'),
+    $('meta[name="title"]').attr('content'),
+    $('title').first().text(),
+    $('h1').first().text(),
+  ];
+
+  for (const candidate of candidates) {
+    const cleaned = candidate?.replace(/\s+/g, ' ').trim();
+    if (cleaned) return cleaned;
+  }
+
+  return null;
+}
+
+function normalizeTeamName(name: string): string {
+  let normalized = name;
+
+  const removalPatterns = [
+    /\bunder\s*[- ]?2[1-9]\b/gi,
+    /\bunder\s*[- ]?1[3-9]\b/gi,
+    /\bunder\s*[- ]?1[0-2]\b/gi,
+    /\bjuniores\b/gi,
+    /\ballievi\b/gi,
+    /\bgiovanissimi\b/gi,
+    /\besordienti\b/gi,
+    /\bpulcini\b/gi,
+    /\bprimi\s+calci\b/gi,
+    /\bserie\s*d\b/gi,
+    /\beccellenza\b/gi,
+    /\bpromozione\b/gi,
+    /\bprima\s+categoria\b/gi,
+    /\bseconda\s+categoria\b/gi,
+    /\bterza\s+categoria\b/gi,
+  ];
+
+  for (const pattern of removalPatterns) {
+    normalized = normalized.replace(pattern, ' ');
+  }
+
+  normalized = normalized
+    .replace(/[|\-–—:,()[\]]/g, ' ')
+    .replace(/\b(stagione|campionato|girone|classifica|calendario|risultati)\b/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return normalized;
+}
+
+function escapeCsv(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  await mkdir(OUTPUT_DIR, { recursive: true });
+
+  console.log(`[INFO] Download sitemap index: ${SITEMAP_INDEX_URL}`);
+  const sitemapIndexXml = await fetchTextWithHandling(SITEMAP_INDEX_URL);
+  if (!sitemapIndexXml) {
+    throw new Error('Impossibile scaricare la sitemap index iniziale.');
+  }
+
+  const childSitemapUrls = extractSitemapUrlsFromXml(sitemapIndexXml);
+  console.log(`[INFO] Sitemap figlie trovate: ${childSitemapUrls.length}`);
+
+  const candidateUrls = new Set<string>();
+
+  for (const sitemapUrl of childSitemapUrls) {
+    const sitemapXml = await fetchTextWithHandling(sitemapUrl);
+    if (!sitemapXml) continue;
+
+    const urls = extractPageUrlsFromSitemap(sitemapXml);
+    for (const url of urls) {
+      if (isLikelyTeamUrl(url)) {
+        candidateUrls.add(url);
+      }
+    }
+  }
+
+  console.log(`[INFO] URL candidati dopo filtro: ${candidateUrls.size}`);
+
+  const rawRows: RawTeamRow[] = [];
+
+  for (const url of candidateUrls) {
+    const html = await fetchTextWithHandling(url);
+    if (!html) continue;
+
+    const originalName = extractTeamNameFromHtml(html);
+    if (!originalName) continue;
+
+    rawRows.push({ originalName, url });
+  }
+
+  const deduped = new Map<string, string>();
+  for (const row of rawRows) {
+    const normalizedName = normalizeTeamName(row.originalName);
+    if (!normalizedName) continue;
+
+    const dedupeKey = normalizedName.toLocaleLowerCase('it-IT');
+    if (!deduped.has(dedupeKey)) {
+      deduped.set(dedupeKey, normalizedName);
+    }
+  }
+
+  const uniqueTeams = Array.from(deduped.values()).sort((a, b) =>
+    a.localeCompare(b, 'it-IT'),
+  );
+
+  const rawCsvLines = ['original_name,url'];
+  for (const row of rawRows) {
+    rawCsvLines.push(`${escapeCsv(row.originalName)},${escapeCsv(row.url)}`);
+  }
+
+  const uniqueCsvLines = ['team_name'];
+  for (const teamName of uniqueTeams) {
+    uniqueCsvLines.push(escapeCsv(teamName));
+  }
+
+  await writeFile(RAW_CSV_PATH, `${rawCsvLines.join('\n')}\n`, 'utf8');
+  await writeFile(UNIQUE_CSV_PATH, `${uniqueCsvLines.join('\n')}\n`, 'utf8');
+
+  console.log('--- RISULTATO ---');
+  console.log(`totale URL sitemap letti: ${candidateUrls.size}`);
+  console.log(`totale squadre raw: ${rawRows.length}`);
+  console.log(`totale squadre unique: ${uniqueTeams.length}`);
+  console.log(`CSV raw: ${RAW_CSV_PATH}`);
+  console.log(`CSV unique: ${UNIQUE_CSV_PATH}`);
+}
+
+main().catch((error) => {
+  console.error('[ERROR] Estrazione fallita:', error);
+  process.exitCode = 1;
+});

--- a/scripts/extract-tuttocampo-teams.ts
+++ b/scripts/extract-tuttocampo-teams.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { XMLParser } from 'fast-xml-parser';
@@ -16,6 +16,15 @@ const UNIQUE_CSV_PATH = path.join(OUTPUT_DIR, 'teams_unique.csv');
 type RawTeamRow = {
   originalName: string;
   url: string;
+};
+
+type CliOptions = {
+  sitemapFile?: string;
+};
+
+type FetchResult = {
+  text: string | null;
+  status: number | null;
 };
 
 const xmlParser = new XMLParser({
@@ -53,25 +62,40 @@ function asArray<T>(value: T | T[] | undefined): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
-async function fetchTextWithHandling(url: string): Promise<string | null> {
+async function fetchTextWithHandling(url: string): Promise<FetchResult> {
   try {
     const response = await rateLimitedFetch(url);
 
     if (response.status === 403) {
       console.warn(`[WARN] 403 Forbidden su: ${url}`);
-      return null;
+      return { text: null, status: 403 };
     }
 
     if (!response.ok) {
       console.warn(`[WARN] HTTP ${response.status} su: ${url}`);
-      return null;
+      return { text: null, status: response.status };
     }
 
-    return await response.text();
+    return { text: await response.text(), status: response.status };
   } catch (error) {
     console.warn(`[WARN] Errore rete su ${url}:`, error);
-    return null;
+    return { text: null, status: null };
   }
+}
+
+function parseCliOptions(argv: string[]): CliOptions {
+  const options: CliOptions = {};
+
+  for (const arg of argv) {
+    if (arg.startsWith('--sitemap-file=')) {
+      const value = arg.split('=').slice(1).join('=').trim();
+      if (value) {
+        options.sitemapFile = value;
+      }
+    }
+  }
+
+  return options;
 }
 
 function extractSitemapUrlsFromXml(xmlText: string): string[] {
@@ -179,22 +203,41 @@ function escapeCsv(value: string): string {
 async function main(): Promise<void> {
   await mkdir(OUTPUT_DIR, { recursive: true });
 
-  console.log(`[INFO] Download sitemap index: ${SITEMAP_INDEX_URL}`);
-  const sitemapIndexXml = await fetchTextWithHandling(SITEMAP_INDEX_URL);
+  const options = parseCliOptions(process.argv.slice(2));
+
+  let sitemapIndexXml: string | null = null;
+  if (options.sitemapFile) {
+    const sitemapPath = path.resolve(process.cwd(), options.sitemapFile);
+    console.log(`[INFO] Lettura sitemap index da file locale: ${sitemapPath}`);
+    sitemapIndexXml = await readFile(sitemapPath, 'utf8');
+  } else {
+    console.log(`[INFO] Download sitemap index: ${SITEMAP_INDEX_URL}`);
+    const sitemapIndexResponse = await fetchTextWithHandling(SITEMAP_INDEX_URL);
+    sitemapIndexXml = sitemapIndexResponse.text;
+  }
+
   if (!sitemapIndexXml) {
-    throw new Error('Impossibile scaricare la sitemap index iniziale.');
+    throw new Error('Impossibile ottenere la sitemap index iniziale.');
   }
 
   const childSitemapUrls = extractSitemapUrlsFromXml(sitemapIndexXml);
   console.log(`[INFO] Sitemap figlie trovate: ${childSitemapUrls.length}`);
 
   const candidateUrls = new Set<string>();
+  let childSitemapsRead = 0;
+  const blockedChildSitemaps: string[] = [];
 
   for (const sitemapUrl of childSitemapUrls) {
-    const sitemapXml = await fetchTextWithHandling(sitemapUrl);
-    if (!sitemapXml) continue;
+    const sitemapResponse = await fetchTextWithHandling(sitemapUrl);
+    if (!sitemapResponse.text) {
+      if (sitemapResponse.status === 403) {
+        blockedChildSitemaps.push(sitemapUrl);
+      }
+      continue;
+    }
 
-    const urls = extractPageUrlsFromSitemap(sitemapXml);
+    childSitemapsRead += 1;
+    const urls = extractPageUrlsFromSitemap(sitemapResponse.text);
     for (const url of urls) {
       if (isLikelyTeamUrl(url)) {
         candidateUrls.add(url);
@@ -207,10 +250,10 @@ async function main(): Promise<void> {
   const rawRows: RawTeamRow[] = [];
 
   for (const url of candidateUrls) {
-    const html = await fetchTextWithHandling(url);
-    if (!html) continue;
+    const pageResponse = await fetchTextWithHandling(url);
+    if (!pageResponse.text) continue;
 
-    const originalName = extractTeamNameFromHtml(html);
+    const originalName = extractTeamNameFromHtml(pageResponse.text);
     if (!originalName) continue;
 
     rawRows.push({ originalName, url });
@@ -244,10 +287,20 @@ async function main(): Promise<void> {
   await writeFile(RAW_CSV_PATH, `${rawCsvLines.join('\n')}\n`, 'utf8');
   await writeFile(UNIQUE_CSV_PATH, `${uniqueCsvLines.join('\n')}\n`, 'utf8');
 
+  if (blockedChildSitemaps.length > 0) {
+    console.log('[WARN] Sitemap figlie bloccate (403):');
+    for (const blockedSitemap of blockedChildSitemaps) {
+      console.log(` - ${blockedSitemap}`);
+    }
+  }
+
   console.log('--- RISULTATO ---');
-  console.log(`totale URL sitemap letti: ${candidateUrls.size}`);
-  console.log(`totale squadre raw: ${rawRows.length}`);
-  console.log(`totale squadre unique: ${uniqueTeams.length}`);
+  console.log(`sitemap figlie trovate: ${childSitemapUrls.length}`);
+  console.log(`sitemap figlie lette correttamente: ${childSitemapsRead}`);
+  console.log(`sitemap figlie bloccate 403: ${blockedChildSitemaps.length}`);
+  console.log(`URL candidati: ${candidateUrls.size}`);
+  console.log(`squadre raw: ${rawRows.length}`);
+  console.log(`squadre unique: ${uniqueTeams.length}`);
   console.log(`CSV raw: ${RAW_CSV_PATH}`);
   console.log(`CSV unique: ${UNIQUE_CSV_PATH}`);
 }


### PR DESCRIPTION
### Motivation

- Estrarre i nomi delle società dilettantistiche e giovanili italiane da Tuttocampo (Serie D fino ai settori giovanili) a partire dalla sitemap pubblica, normalizzarli e deduplicarli in un CSV finale.

### Description

- Aggiunto lo script `scripts/extract-tuttocampo-teams.ts` che legge la sitemap index `https://www.tuttocampo.it/Sitemap/Index2025_26.xml`, scarica le sitemap figlie con rate limit di 1.5s, filtra URL rilevanti e estrae i nomi da `og:title`/`meta title`/`title`/`h1` usando `fetch` + `cheerio` + `fast-xml-parser`.
- Normalizzazione dei nomi rimuovendo suffissi/categorie (es. `Under 17`, `Juniores`, `Serie D`, `Eccellenza`, ecc.), deduplicazione case-insensitive, ordinamento alfabetico e generazione di due CSV in `data/tuttocampo`: `teams_raw.csv` (`original_name,url`) e `teams_unique.csv` (`team_name`).
- Aggiornato `package.json` con lo script `extract:tuttocampo` e aggiunte le dipendenze leggere `cheerio`, `fast-xml-parser` e il dev tool `tsx`; aggiunta la traccia della directory di output con `data/tuttocampo/.gitkeep`.
- Gestione non bloccante di errori HTTP come `403` (loggati e si continua), evita l'uso di browser automation pesante e rispetta il rate limit richiesto.

### Testing

- Eseguito `pnpm install` per allineare le nuove dipendenze e aggiornare `pnpm-lock.yaml`, e l'installazione è andata a buon fine.
- Eseguito `pnpm run typecheck` e il controllo TypeScript ha passato con esito positivo dopo l'installazione delle dipendenze.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3605972fc832b922e82c252b2122f)