### PR TITLE
Fix follower notification deep link to club/player profiles

### DIFF
--- a/components/notifications/NotificationItem.tsx
+++ b/components/notifications/NotificationItem.tsx
@@ -106,6 +106,13 @@ function formatRelative(dateStr: string) {
 }
 
 export default function NotificationItem({ notification, onClick, compact }: Props) {
+  const profileHref = (profileId: string, accountType?: string | null) => {
+    const normalized = (accountType || '').toLowerCase();
+    if (normalized === 'player' || normalized === 'athlete') return `/players/${profileId}`;
+    if (normalized === 'club') return `/clubs/${profileId}`;
+    return `/profiles/${profileId}`;
+  };
+
   const hrefFromPayload = () => {
     const payload = notification.payload || {};
     if (notification.kind === 'new_message' || notification.kind === 'message') {
@@ -120,8 +127,14 @@ export default function NotificationItem({ notification, onClick, compact }: Pro
         return `/messages/${senderId}`;
       }
     }
-    if (notification.kind === 'new_follower' && typeof payload.follower_profile_id === 'string') {
-      return `/profiles/${payload.follower_profile_id}`;
+    if (notification.kind === 'new_follower') {
+      const followerProfileId =
+        typeof payload.follower_profile_id === 'string'
+          ? payload.follower_profile_id
+          : notification.actor_profile_id;
+      if (typeof followerProfileId === 'string' && followerProfileId.trim()) {
+        return profileHref(followerProfileId, notification.actor?.account_type);
+      }
     }
     if (notification.kind === 'new_comment' && typeof payload.post_id === 'string' && payload.post_id.trim()) {
       return `/posts/${payload.post_id}`;


### PR DESCRIPTION
### Motivation
- Align desktop notification click behavior with mobile: when a `new_follower` notification is clicked it should open the follower's profile page for the correct entity type (player or club).

### Description
- Added a `profileHref` helper to map `account_type` to the correct route (`player`/`athlete` → `/players/:id`, `club` → `/clubs/:id`, fallback → `/profiles/:id`) in `components/notifications/NotificationItem.tsx`.
- Updated `hrefFromPayload` handling of `new_follower` to prefer `payload.follower_profile_id` and fall back to `notification.actor_profile_id` if missing, then build the URL via `profileHref`.
- Change is limited to notification deep-linking logic and preserves existing handlers for other notification kinds.

### Testing
- Ran linter on the modified file with `pnpm -s eslint components/notifications/NotificationItem.tsx` and it completed successfully.
- File changes were validated locally and committed (`components/notifications/NotificationItem.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3744b8160832b92d6ad8400e706de)