### PR TITLE
Add UGC moderation: terms, report/block APIs, feed filtering and UI actions

### DIFF
--- a/app/(dashboard)/feed/page.tsx
+++ b/app/(dashboard)/feed/page.tsx
@@ -64,6 +64,7 @@ export default function FeedPage() {
   } | null>(null);
   const [starterPackLoading, setStarterPackLoading] = useState(false);
   const [starterPackError, setStarterPackError] = useState<string | null>(null);
+  const [blockedProfileIds, setBlockedProfileIds] = useState<Set<string>>(new Set());
 
   const {
     posts: feedPosts,
@@ -78,7 +79,14 @@ export default function FeedPage() {
     updatePost,
     removePost,
   } = useFeed();
-  const posts = feedPosts;
+  const posts = useMemo(
+    () =>
+      feedPosts.filter((post) => {
+        const authorProfileId = post.author_profile?.id ?? post.author_profile_id ?? null;
+        return !authorProfileId || !blockedProfileIds.has(String(authorProfileId));
+      }),
+    [feedPosts, blockedProfileIds],
+  );
   const errorMessage = error?.message ?? null;
   const canCreatePost =
     Boolean(currentUserId) &&
@@ -342,6 +350,14 @@ export default function FeedPage() {
     removePost(id);
   }
 
+  function onAuthorBlocked(blockedProfileId: string) {
+    setBlockedProfileIds((curr) => {
+      const next = new Set(curr);
+      next.add(String(blockedProfileId));
+      return next;
+    });
+  }
+
   return (
     <div className="pb-6" aria-labelledby={headingId}>
       {/* layout a 2 colonne: sx (minicard) / centro (composer + post) */}
@@ -450,6 +466,7 @@ export default function FeedPage() {
                     currentUserId={currentUserId}
                     onUpdated={onPostUpdated}
                     onDeleted={onPostDeleted}
+                    onAuthorBlocked={onAuthorBlocked}
                     reaction={reactions[String(p.id)] ?? createDefaultReaction()}
                     commentCount={commentCounts[String(p.id)] ?? 0}
                     pickerOpen={pickerFor === String(p.id)}

--- a/app/(dashboard)/onboarding/page.tsx
+++ b/app/(dashboard)/onboarding/page.tsx
@@ -63,6 +63,12 @@ export default function OnboardingPage() {
       <p className="text-gray-600">
         Completa il tuo profilo per iniziare.
       </p>
+      <p className="text-sm text-gray-600">
+        Proseguendo accetti i{' '}
+        <a href="/legal/terms" className="underline" target="_blank" rel="noreferrer">Termini di utilizzo</a>{' '}
+        e la{' '}
+        <a href="/legal/privacy" className="underline" target="_blank" rel="noreferrer">Privacy Policy</a>.
+      </p>
       {/* …il tuo form di onboarding… */}
     </div>
   )

--- a/app/api/blocks/route.ts
+++ b/app/api/blocks/route.ts
@@ -2,17 +2,52 @@ import { NextRequest } from 'next/server';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
 import { getActiveProfile } from '@/lib/api/profile';
 
-export async function POST(req: NextRequest) {
+async function getCurrentProfile() {
   const supabase = await getSupabaseServerClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
+  if (!user) return { supabase, user: null, profile: null as any };
+
+  const profile = await getActiveProfile(supabase, user.id);
+  return { supabase, user, profile };
+}
+
+export async function GET() {
+  const { supabase, user, profile } = await getCurrentProfile();
+  if (!user) return Response.json({ error: 'not_authenticated' }, { status: 401 });
+  if (!profile?.id) return Response.json({ error: 'profile_not_found' }, { status: 400 });
+
+  const { data, error } = await supabase
+    .from('profile_blocks')
+    .select('blocked_profile_id, profiles:blocked_profile_id(id, display_name, full_name, avatar_url, account_type)')
+    .eq('blocker_profile_id', profile.id)
+    .order('created_at', { ascending: false });
+
+  if (error) return Response.json({ error: error.message }, { status: 400 });
+
+  const items = (data ?? []).map((row: any) => {
+    const p = row?.profiles ?? null;
+    return {
+      blocked_profile_id: String(row.blocked_profile_id),
+      display_name: p?.display_name ?? null,
+      full_name: p?.full_name ?? null,
+      avatar_url: p?.avatar_url ?? null,
+      account_type: p?.account_type ?? null,
+    };
+  });
+
+  return Response.json({ ok: true, items });
+}
+
+export async function POST(req: NextRequest) {
+  const { supabase, user, profile } = await getCurrentProfile();
+
   if (!user) {
     return Response.json({ error: 'not_authenticated' }, { status: 401 });
   }
 
-  const profile = await getActiveProfile(supabase, user.id);
   if (!profile?.id) {
     return Response.json({ error: 'profile_not_found' }, { status: 400 });
   }
@@ -37,5 +72,24 @@ export async function POST(req: NextRequest) {
     return Response.json({ error: error.message }, { status: 400 });
   }
 
+  return Response.json({ ok: true });
+}
+
+export async function DELETE(req: NextRequest) {
+  const { supabase, user, profile } = await getCurrentProfile();
+  if (!user) return Response.json({ error: 'not_authenticated' }, { status: 401 });
+  if (!profile?.id) return Response.json({ error: 'profile_not_found' }, { status: 400 });
+
+  const body = await req.json().catch(() => null);
+  const blockedProfileId = typeof body?.blockedProfileId === 'string' ? body.blockedProfileId.trim() : '';
+  if (!blockedProfileId) return Response.json({ error: 'invalid_payload' }, { status: 400 });
+
+  const { error } = await supabase
+    .from('profile_blocks')
+    .delete()
+    .eq('blocker_profile_id', profile.id)
+    .eq('blocked_profile_id', blockedProfileId);
+
+  if (error) return Response.json({ error: error.message }, { status: 400 });
   return Response.json({ ok: true });
 }

--- a/app/api/blocks/route.ts
+++ b/app/api/blocks/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { getActiveProfile } from '@/lib/api/profile';
+
+export async function POST(req: NextRequest) {
+  const supabase = await getSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return Response.json({ error: 'not_authenticated' }, { status: 401 });
+  }
+
+  const profile = await getActiveProfile(supabase, user.id);
+  if (!profile?.id) {
+    return Response.json({ error: 'profile_not_found' }, { status: 400 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const blockedProfileId = typeof body?.blockedProfileId === 'string' ? body.blockedProfileId.trim() : '';
+
+  if (!blockedProfileId) {
+    return Response.json({ error: 'invalid_payload' }, { status: 400 });
+  }
+
+  if (blockedProfileId === profile.id) {
+    return Response.json({ error: 'cannot_block_self' }, { status: 400 });
+  }
+
+  const { error } = await supabase.from('profile_blocks').insert({
+    blocker_profile_id: profile.id,
+    blocked_profile_id: blockedProfileId,
+  });
+
+  if (error && error.code !== '23505') {
+    return Response.json({ error: error.message }, { status: 400 });
+  }
+
+  return Response.json({ ok: true });
+}

--- a/app/api/feed/posts/route.ts
+++ b/app/api/feed/posts/route.ts
@@ -503,6 +503,21 @@ export async function GET(req: NextRequest) {
         attachAuthorProfile(r, { byUserId: authorProfileMapByUserId, byProfileId: authorProfileMapByProfileId }),
       )
       .map((r) => normalizeRow(r, quotedMap ?? undefined)) || [];
+
+  if (currentProfileId) {
+    const { data: blockedRows } = await supabase
+      .from('profile_blocks')
+      .select('blocked_profile_id')
+      .eq('blocker_profile_id', currentProfileId);
+    const blockedSet = new Set((blockedRows ?? []).map((row: any) => String(row.blocked_profile_id)).filter(Boolean));
+    if (blockedSet.size > 0) {
+      rows = rows.filter((row: any) => {
+        const authorProfileId = row?.author_profile?.id ?? row?.author_profile_id ?? null;
+        return !authorProfileId || !blockedSet.has(String(authorProfileId));
+      });
+    }
+  }
+
   rows = await attachVerifiedFlags(rows);
   const postsCountAfterJoin = rows.length;
 

--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { getActiveProfile } from '@/lib/api/profile';
+
+export async function POST(req: NextRequest) {
+  const supabase = await getSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return Response.json({ error: 'not_authenticated' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const targetType = typeof body?.targetType === 'string' ? body.targetType : '';
+  const targetId = typeof body?.targetId === 'string' ? body.targetId.trim() : '';
+  const reason = typeof body?.reason === 'string' ? body.reason.trim() : null;
+
+  if (!['post', 'comment', 'profile'].includes(targetType) || !targetId) {
+    return Response.json({ error: 'invalid_payload' }, { status: 400 });
+  }
+
+  const profile = await getActiveProfile(supabase, user.id);
+
+  const { error } = await supabase.from('ugc_reports').insert({
+    reporter_user_id: user.id,
+    reporter_profile_id: profile?.id ?? null,
+    target_type: targetType,
+    target_id: targetId,
+    reason: reason || null,
+  });
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 400 });
+  }
+
+  return Response.json({ ok: true });
+}

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -37,6 +37,16 @@ export default function TermsPage() {
         </p>
       </section>
 
+      <section className="mt-8 space-y-3 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+        <h2 className="text-lg font-semibold">Tolleranza zero per contenuti offensivi o utenti abusivi</h2>
+        <ul className="list-disc space-y-2 pl-6">
+          <li>Non sono tollerati contenuti offensivi, abusivi, discriminatori, minacciosi, spam o illegali.</li>
+          <li>Gli utenti possono segnalare contenuti e profili tramite le funzioni di segnalazione disponibili nella piattaforma.</li>
+          <li>Gli utenti possono bloccare altri utenti per non visualizzarne più i contenuti nel proprio feed.</li>
+          <li>Club &amp; Player può rimuovere contenuti e/o sospendere account che violano queste regole o i presenti Termini.</li>
+        </ul>
+      </section>
+
       <section className="mt-8 space-y-3 text-sm text-neutral-700 dark:text-neutral-200">
         <h2 className="text-lg font-semibold">Limitazione di responsabilità</h2>
         <p>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -231,6 +231,18 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY`}
           </button>
         </form>
 
+        <p className="text-center text-xs text-gray-600">
+          Accedendo accetti i{' '}
+          <a href="/legal/terms" className="underline" target="_blank" rel="noreferrer">
+            Termini di utilizzo
+          </a>{' '}
+          e la{' '}
+          <a href="/legal/privacy" className="underline" target="_blank" rel="noreferrer">
+            Privacy Policy
+          </a>
+          .
+        </p>
+
         {currentEmail && (
           <div className="mt-2 text-center text-xs text-gray-600">
             Sei loggato come <strong>{currentEmail}</strong>.{' '}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,6 +17,14 @@ type Profile = {
   notify_email_new_message: boolean | null
 }
 
+type BlockedItem = {
+  blocked_profile_id: string
+  display_name: string | null
+  full_name: string | null
+  avatar_url: string | null
+  account_type: 'athlete' | 'club' | 'fan' | null
+}
+
 export default function SettingsPage() {
   const supabase = useMemo(() => supabaseBrowser(), [])
   const router = useRouter()
@@ -31,6 +39,10 @@ export default function SettingsPage() {
   const [userId, setUserId] = useState<string | null>(null)
   const [accountType, setAccountType] = useState<'athlete' | 'club' | 'fan' | null>(null)
   const [notifyEmailNewMessage, setNotifyEmailNewMessage] = useState<boolean>(false)
+  const [blockedUsers, setBlockedUsers] = useState<BlockedItem[]>([])
+  const [blockedLoading, setBlockedLoading] = useState(false)
+  const [blockedMsg, setBlockedMsg] = useState('')
+  const [unblockingId, setUnblockingId] = useState<string | null>(null)
 
   useEffect(() => {
     const load = async () => {
@@ -61,6 +73,17 @@ export default function SettingsPage() {
       setAccountType(p?.account_type ?? null)
       setNotifyEmailNewMessage(!!p?.notify_email_new_message)
       setLoading(false)
+
+      setBlockedLoading(true)
+      const blocksRes = await fetch('/api/blocks', { credentials: 'include', cache: 'no-store' })
+      const blocksJson = await blocksRes.json().catch(() => ({}))
+      if (blocksRes.ok && blocksJson?.ok) {
+        setBlockedUsers(Array.isArray(blocksJson.items) ? blocksJson.items : [])
+        setBlockedMsg('')
+      } else {
+        setBlockedMsg(blocksJson?.error || 'Errore nel caricamento utenti bloccati.')
+      }
+      setBlockedLoading(false)
     }
 
     load()
@@ -132,6 +155,30 @@ export default function SettingsPage() {
     // se non c'è history (es. aperto da link diretto), vai al feed
     if (typeof window !== 'undefined' && window.history.length > 1) router.back()
     else router.push('/feed')
+  }
+
+  const unblockUser = async (blockedProfileId: string) => {
+    if (unblockingId) return
+    setBlockedMsg('')
+    setUnblockingId(blockedProfileId)
+    try {
+      const res = await fetch('/api/blocks', {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ blockedProfileId }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok || !body?.ok) {
+        setBlockedMsg(body?.error || 'Errore durante lo sblocco.')
+        return
+      }
+      setBlockedUsers((curr) => curr.filter((item) => item.blocked_profile_id !== blockedProfileId))
+    } catch {
+      setBlockedMsg('Errore di rete durante lo sblocco.')
+    } finally {
+      setUnblockingId(null)
+    }
   }
 
   const accountTypeLabel = accountType === 'athlete'
@@ -227,6 +274,45 @@ export default function SettingsPage() {
             >
               Logout
             </button>
+          </section>
+
+          <section style={{ border: '1px solid #e5e7eb', borderRadius: 12, padding: 16 }}>
+            <h2 style={{ marginTop: 0 }}>Utenti bloccati</h2>
+            {blockedLoading ? <p>Caricamento utenti bloccati…</p> : null}
+            {blockedMsg ? <p style={{ color: '#b91c1c' }}>{blockedMsg}</p> : null}
+            {!blockedLoading && blockedUsers.length === 0 ? <p>Non hai bloccato nessun utente.</p> : null}
+
+            {!blockedLoading && blockedUsers.length > 0 ? (
+              <ul style={{ display: 'grid', gap: 10, margin: 0, padding: 0, listStyle: 'none' }}>
+                {blockedUsers.map((item) => {
+                  const label = item.display_name || item.full_name || item.blocked_profile_id
+                  const typeLabel = item.account_type === 'athlete' ? 'Player' : item.account_type === 'club' ? 'Club' : item.account_type === 'fan' ? 'Fan' : '—'
+                  return (
+                    <li key={item.blocked_profile_id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, border: '1px solid #e5e7eb', borderRadius: 10, padding: 10 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        {item.avatar_url ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={item.avatar_url} alt={label} style={{ width: 36, height: 36, borderRadius: '9999px', objectFit: 'cover' }} />
+                        ) : (
+                          <div style={{ width: 36, height: 36, borderRadius: '9999px', background: '#e5e7eb' }} aria-hidden />
+                        )}
+                        <div>
+                          <p style={{ margin: 0, fontWeight: 600 }}>{label}</p>
+                          <p style={{ margin: 0, fontSize: 13, color: '#6b7280' }}>{typeLabel}</p>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => unblockUser(item.blocked_profile_id)}
+                        disabled={unblockingId === item.blocked_profile_id}
+                        style={{ padding: '8px 12px', borderRadius: 8, border: '1px solid #e5e7eb', background: '#fff', cursor: 'pointer' }}
+                      >
+                        {unblockingId === item.blocked_profile_id ? 'Sblocco…' : 'Sblocca'}
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : null}
           </section>
 
           <section style={{ border: '1px solid #fecaca', borderRadius: 12, padding: 16, background: '#fff7f7' }}>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -195,6 +195,18 @@ export default function SignupPage() {
             </form>
 
             <p className="mt-6 text-center text-base font-semibold text-gray-700 dark:text-gray-200">
+              Registrandoti accetti i{' '}
+              <a href="/legal/terms" className="underline underline-offset-4" target="_blank" rel="noreferrer">
+                Termini di utilizzo
+              </a>{' '}
+              e la{' '}
+              <a href="/legal/privacy" className="underline underline-offset-4" target="_blank" rel="noreferrer">
+                Privacy Policy
+              </a>
+              .
+            </p>
+
+            <p className="text-center text-base font-semibold text-gray-700 dark:text-gray-200">
               Hai già un account?{' '}
               <a href="/login" className="link underline underline-offset-4">
                 Accedi

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -88,7 +88,7 @@ export default function SignupPage() {
           <BrandLogo variant="signup" unlinked />
           <div className="space-y-4">
             <h2 className="text-3xl font-bold leading-tight text-[#00527a] sm:text-4xl">
-              <em>entra a far parte di questo nuovo progetto!</em>
+              entra a far parte di questo nuovo progetto!
             </h2>
             <p className="text-lg leading-relaxed text-slate-800">
               Registrati come <b>CLUB</b> o come <b>PLAYER</b>, pubblica opportunità, costruisci la tua carriera.
@@ -195,15 +195,17 @@ export default function SignupPage() {
             </form>
 
             <p className="mt-6 text-center text-base font-semibold text-gray-700 dark:text-gray-200">
-              Registrandoti accetti i{' '}
-              <a href="/legal/terms" className="underline underline-offset-4" target="_blank" rel="noreferrer">
-                Termini di utilizzo
-              </a>{' '}
-              e la{' '}
-              <a href="/legal/privacy" className="underline underline-offset-4" target="_blank" rel="noreferrer">
-                Privacy Policy
-              </a>
-              .
+              <span className="block">Registrandoti accetti</span>
+              <span className="block">
+                <a href="/legal/terms" className="underline underline-offset-4" target="_blank" rel="noreferrer">
+                  Termini di utilizzo
+                </a>{' '}
+                e la{' '}
+                <a href="/legal/privacy" className="underline underline-offset-4" target="_blank" rel="noreferrer">
+                  Privacy Policy
+                </a>
+                .
+              </span>
             </p>
 
             <p className="text-center text-base font-semibold text-gray-700 dark:text-gray-200">

--- a/components/feed/PostCard.tsx
+++ b/components/feed/PostCard.tsx
@@ -68,6 +68,7 @@ export type PostCardProps = {
   onCommentCountChange?: (next: number) => void;
   onUpdated?: (next: FeedPost) => void;
   onDeleted?: (id: string) => void;
+  onAuthorBlocked?: (blockedProfileId: string) => void;
 };
 
 export function PostCard({
@@ -82,6 +83,7 @@ export function PostCard({
   onClosePicker,
   onToggleReaction,
   onCommentCountChange,
+  onAuthorBlocked,
 }: PostCardProps) {
   const LONG_PRESS_MS = 500;
   const isEvent = (post.kind ?? 'normal') === 'event';
@@ -117,6 +119,7 @@ export function PostCard({
   const [shareOpen, setShareOpen] = useState(false);
   const [shareUrl, setShareUrl] = useState('');
   const [shareLoading, setShareLoading] = useState(false);
+  const [moderationLoading, setModerationLoading] = useState(false);
   const linkUrl = post.link_url ?? firstUrl(description);
   const linkTitle = post.link_title ?? null;
   const linkDescription = post.link_description ?? null;
@@ -236,6 +239,52 @@ export function PostCard({
     }
   }
 
+  async function reportPost() {
+    if (!confirm('Vuoi segnalare questo contenuto?')) return;
+    setModerationLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/reports', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetType: 'post', targetId: String(post.id) }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json?.ok) throw new Error(json?.error || 'Segnalazione non inviata');
+    } catch (e: any) {
+      setError(e?.message || 'Errore');
+    } finally {
+      setModerationLoading(false);
+    }
+  }
+
+  async function blockAuthor() {
+    const blockedProfileId = authorProfile?.id ?? post.author_profile_id ?? null;
+    if (!blockedProfileId) {
+      setError('Profilo autore non disponibile');
+      return;
+    }
+    if (!confirm('Bloccare questo autore? I suoi contenuti spariranno subito dal tuo feed.')) return;
+    setModerationLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/blocks', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ blockedProfileId }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json?.ok) throw new Error(json?.error || 'Blocco non riuscito');
+      onAuthorBlocked?.(String(blockedProfileId));
+    } catch (e: any) {
+      setError(e?.message || 'Errore');
+    } finally {
+      setModerationLoading(false);
+    }
+  }
+
   return (
     <article className="relative mb-4 overflow-hidden rounded-xl border border-slate-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md md:p-5">
       <div className="flex items-start justify-between gap-4">
@@ -332,6 +381,26 @@ export function PostCard({
           >
             <PostIconShare className={actionIconClass} aria-hidden />
           </button>
+          {!isOwner ? (
+            <>
+              <button
+                type="button"
+                onClick={reportPost}
+                className="rounded-full px-2 py-1 text-xs transition hover:bg-neutral-100 hover:text-neutral-900"
+                disabled={moderationLoading}
+              >
+                Segnala
+              </button>
+              <button
+                type="button"
+                onClick={blockAuthor}
+                className="rounded-full px-2 py-1 text-xs transition hover:bg-neutral-100 hover:text-neutral-900"
+                disabled={moderationLoading}
+              >
+                Blocca autore
+              </button>
+            </>
+          ) : null}
         </div>
       </div>
       {editing ? (

--- a/supabase/migrations/20261030100000_ugc_reports_and_profile_blocks.sql
+++ b/supabase/migrations/20261030100000_ugc_reports_and_profile_blocks.sql
@@ -1,0 +1,63 @@
+create table if not exists public.ugc_reports (
+  id uuid primary key default gen_random_uuid(),
+  reporter_user_id uuid not null references auth.users(id) on delete cascade,
+  reporter_profile_id uuid null references public.profiles(id) on delete set null,
+  target_type text not null check (target_type in ('post', 'comment', 'profile')),
+  target_id text not null,
+  reason text null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_ugc_reports_target on public.ugc_reports(target_type, target_id);
+create index if not exists idx_ugc_reports_reporter on public.ugc_reports(reporter_user_id);
+
+alter table public.ugc_reports enable row level security;
+
+drop policy if exists "ugc_reports_insert_own" on public.ugc_reports;
+create policy "ugc_reports_insert_own"
+  on public.ugc_reports
+  for insert
+  to authenticated
+  with check (auth.uid() = reporter_user_id);
+
+create table if not exists public.profile_blocks (
+  id uuid primary key default gen_random_uuid(),
+  blocker_profile_id uuid not null references public.profiles(id) on delete cascade,
+  blocked_profile_id uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  constraint profile_blocks_no_self check (blocker_profile_id <> blocked_profile_id),
+  constraint profile_blocks_unique unique (blocker_profile_id, blocked_profile_id)
+);
+
+create index if not exists idx_profile_blocks_blocker on public.profile_blocks(blocker_profile_id);
+create index if not exists idx_profile_blocks_blocked on public.profile_blocks(blocked_profile_id);
+
+alter table public.profile_blocks enable row level security;
+
+drop policy if exists "profile_blocks_insert_own" on public.profile_blocks;
+create policy "profile_blocks_insert_own"
+  on public.profile_blocks
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = blocker_profile_id
+        and p.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "profile_blocks_select_participants" on public.profile_blocks;
+create policy "profile_blocks_select_participants"
+  on public.profile_blocks
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where (p.id = blocker_profile_id or p.id = blocked_profile_id)
+        and p.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
### Motivation
- Adeguare l’app a Apple Guideline 1.2 richiedendo visibilità dei Termini prima dell’accesso a UGC e fornendo meccanismi di moderazione in-app (segnalazione e blocco).
- Garantire che gli utenti possano bloccare altri autori e che i loro contenuti scompaiano immediatamente dal feed di chi blocca.
- Fornire endpoint backend sicuri per conservare segnalazioni e registrare blocchi, con migrazioni schema-safe per Supabase.

### Description
- Aggiunta sezione esplicita "Tolleranza zero per contenuti offensivi o utenti abusivi" in `app/legal/terms/page.tsx` e link visibili a Termini/Privacy su `signup`, `login` e onboarding senza introdurre flow complessi di consenso.
- Nuovi endpoint autenticati: `POST /api/reports` salva segnalazioni in `ugc_reports` con reporter user/profile e ritorna `{ ok: true }`, e `POST /api/blocks` registra blocchi in `profile_blocks` con controllo self-block e deduplica sicura.
- Migrazione `supabase/migrations/20261030100000_ugc_reports_and_profile_blocks.sql` che crea tabelle `ugc_reports` e `profile_blocks` con indici e policy RLS per operazioni sicure.
- Feed API aggiornato (`app/api/feed/posts/route.ts`) per escludere post degli autori bloccati dall’utente corrente; UI aggiornata (`components/feed/PostCard.tsx`) con pulsanti "Segnala" e "Blocca autore" che chiamano gli endpoint e confermano l’azione.
- Comportamento client: dopo un blocco da UI il post dell’autore viene rimosso immediatamente dal feed in memoria (`app/(dashboard)/feed/page.tsx`) senza necessità di refresh, mantenendo intatte reazioni/commenti/funzioni esistenti.

### Testing
- Eseguito `pnpm lint` senza errori (OK).
- Eseguito `pnpm run build` che ha fallito per problemi di rete esterni durante il fetch dei Google Fonts (`Inter`, `Righteous`) e non per errori del codice; segnalo come cause di build legate a risorse esterne.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3acb63dec832ba3ae2e2a77c3bd0d)