### PR TITLE
feed: icone per Segnala/Blocca e riordino azioni (Segnala → Blocca autore → Condividi)

### DIFF
--- a/components/feed/PostCard.tsx
+++ b/components/feed/PostCard.tsx
@@ -56,6 +56,25 @@ function FeedLinkCard({
   );
 }
 
+function IconReport({ className = 'h-5 w-5' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={className} aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 16h.01" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10.3 3.6 2.8 16.4A2 2 0 0 0 4.5 19h15a2 2 0 0 0 1.7-2.6L13.7 3.6a2 2 0 0 0-3.4 0Z" />
+    </svg>
+  );
+}
+
+function IconBlock({ className = 'h-5 w-5' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={className} aria-hidden>
+      <circle cx="12" cy="12" r="8" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="m8.5 8.5 7 7" />
+    </svg>
+  );
+}
+
 export type PostCardProps = {
   post: FeedPost;
   currentUserId: string | null;
@@ -372,6 +391,28 @@ export function PostCard({
             </>
           ) : null}
 
+          {!isOwner ? (
+            <>
+              <button
+                type="button"
+                onClick={reportPost}
+                aria-label="Segnala questo post"
+                className="rounded-full p-2 text-slate-500 transition hover:bg-neutral-100 hover:text-neutral-900"
+                disabled={moderationLoading}
+              >
+                <IconReport className={actionIconClass} />
+              </button>
+              <button
+                type="button"
+                onClick={blockAuthor}
+                aria-label="Blocca autore"
+                className="rounded-full p-2 text-red-700 transition hover:bg-red-50 hover:text-red-800"
+                disabled={moderationLoading}
+              >
+                <IconBlock className={actionIconClass} />
+              </button>
+            </>
+          ) : null}
           <button
             type="button"
             onClick={handleShare}
@@ -381,26 +422,6 @@ export function PostCard({
           >
             <PostIconShare className={actionIconClass} aria-hidden />
           </button>
-          {!isOwner ? (
-            <>
-              <button
-                type="button"
-                onClick={reportPost}
-                className="rounded-full px-2 py-1 text-xs transition hover:bg-neutral-100 hover:text-neutral-900"
-                disabled={moderationLoading}
-              >
-                Segnala
-              </button>
-              <button
-                type="button"
-                onClick={blockAuthor}
-                className="rounded-full px-2 py-1 text-xs transition hover:bg-neutral-100 hover:text-neutral-900"
-                disabled={moderationLoading}
-              >
-                Blocca autore
-              </button>
-            </>
-          ) : null}
         </div>
       </div>
       {editing ? (

--- a/components/feed/PostCard.tsx
+++ b/components/feed/PostCard.tsx
@@ -58,7 +58,7 @@ function FeedLinkCard({
 
 function IconReport({ className = 'h-5 w-5' }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={className} aria-hidden>
+    <svg viewBox="0 0 24 24" fill="none" stroke="#6B7280" strokeWidth="2.4" className={className} aria-hidden>
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 16h.01" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M10.3 3.6 2.8 16.4A2 2 0 0 0 4.5 19h15a2 2 0 0 0 1.7-2.6L13.7 3.6a2 2 0 0 0-3.4 0Z" />
@@ -68,7 +68,7 @@ function IconReport({ className = 'h-5 w-5' }: { className?: string }) {
 
 function IconBlock({ className = 'h-5 w-5' }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={className} aria-hidden>
+    <svg viewBox="0 0 24 24" fill="none" stroke="#B0262D" strokeWidth="2.4" className={className} aria-hidden>
       <circle cx="12" cy="12" r="8" />
       <path strokeLinecap="round" strokeLinejoin="round" d="m8.5 8.5 7 7" />
     </svg>
@@ -397,19 +397,19 @@ export function PostCard({
                 type="button"
                 onClick={reportPost}
                 aria-label="Segnala questo post"
-                className="rounded-full p-2 text-slate-500 transition hover:bg-neutral-100 hover:text-neutral-900"
+                className="rounded-full p-2 transition hover:bg-neutral-100"
                 disabled={moderationLoading}
               >
-                <IconReport className={actionIconClass} />
+                <IconReport className="h-5 w-5" />
               </button>
               <button
                 type="button"
                 onClick={blockAuthor}
                 aria-label="Blocca autore"
-                className="rounded-full p-2 text-red-700 transition hover:bg-red-50 hover:text-red-800"
+                className="rounded-full p-2 transition hover:bg-red-50"
                 disabled={moderationLoading}
               >
-                <IconBlock className={actionIconClass} />
+                <IconBlock className="h-5 w-5" />
               </button>
             </>
           ) : null}


### PR DESCRIPTION
### Motivation
- Adeguare l'interfaccia della card post alla grafica richiesta rendendo le azioni icon-only e usando le icone viste negli screenshot.
- Assicurare che le azioni sui post non appartenenti all'utente siano nell'ordine corretto: `Segnala`, `Blocca autore`, `Condividi`.

### Description
- Sostituiti i pulsanti testuali `Segnala` e `Blocca autore` con pulsanti icona cliccabili e aggiunte due icone inline `IconReport` e `IconBlock` in `components/feed/PostCard.tsx`.
- Riordinate le azioni nella UI per non-owner in `PostCard` così da mostrare prima `Segnala`, poi `Blocca autore`, e infine `Condividi`.
- Mantenuti gli attributi di accessibilità tramite `aria-label` e gli stati `disabled`, oltre alle classi di hover/tasto esistenti per preservare il comportamento tattile e visivo.
- Il pulsante `Condividi` continua a usare l'icona esistente `PostIconShare` e ora è posizionato come ultima azione.

### Testing
- Eseguito `npm run -s lint` e la verifica del linter è passata con esito positivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5dd794d9c832b93af33ea87b35263)